### PR TITLE
fix: set NODE_ENV to testing when running npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "client": "webpack-dev-server --mode development --devtool inline-source-map --hot",
     "coverage": "jest --coverage",
     "server": "nodemon server/app.js",
-    "test": "jest",
+    "test": "NODE_ENV=testing jest --runInBand",
     "dev": "concurrently \"npm run server\" \"npm run client\"",
     "sequelize:migrate": "cd ./server && npx sequelize db:migrate",
     "eslint": "npx eslint client/"


### PR DESCRIPTION
This change sets the environment variable `NODE_ENV` to `testing` in `package.json`. This is necessary to allow the `.github/workflows/main.yml` main workflow to pass checks when introducing code changes with integration tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Chores**
	- Updated the test script for better performance and environment specificity.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->