### PR TITLE
chore: restful backend

### DIFF
--- a/server/__tests__/routeTests/division.routes.test.js
+++ b/server/__tests__/routeTests/division.routes.test.js
@@ -26,41 +26,12 @@ describe("Division routes", () => {
     await Group.destroy({ where: {} });
   });
 
-  describe("GET /divisions/:groupId", () => {
-    it("Should get a division by its group id", async () => {
-      const group = await TestDataGenerator.createDummyGroup("Group Uno");
-      await Division.create({ group_id: group.id, name: "Division 1" });
-      await Division.create({ group_id: group.id, name: "Division 2" });
-
-      const response = await request(app)
-        .get(`/divisions/${group.id}`)
-        .send();
-
-      expect(response.status).toBe(200);
-      expect(response.body.length).toBe(2);
-    });
-
-    it("Should fail if group not found", async () => {
-      const invalidId = 99;
-      const response = await request(app)
-        .get(`/divisions/${invalidId}`)
-        .send();
-
-      expect(response.status).toBe(404);
-      expect(response.body).toMatchObject({
-        message: `no such ${Group.name} found for id ${invalidId}`,
-      });
-    });
-  });
-
   describe("POST /divisions", () => {
     it("Should create a division", async () => {
       const group = await TestDataGenerator.createDummyGroup("Group Tres");
       const form = { group_id: group.id, name: "New Division" };
 
-      const response = await request(app)
-        .post("/divisions")
-        .send(form);
+      const response = await request(app).post("/divisions").send(form);
 
       expect(response.status).toBe(201);
       expect(response.body).toEqual(expect.objectContaining({ name: form.name }));
@@ -70,21 +41,23 @@ describe("Division routes", () => {
       const group = await TestDataGenerator.createDummyGroup("Group Cuatro");
       const form = { group_id: group.id, name: "f" };
 
-      const response = await request(app)
-        .post("/divisions")
-        .send(form);
+      const response = await request(app).post("/divisions").send(form);
 
       expect(response.status).toBe(500);
       expect(response.body).toMatchObject({
-        message: "Validation error: Division name must be between 2 and 50 characters long",
-      })
+        message:
+          "Validation error: Division name must be between 2 and 50 characters long",
+      });
     });
   });
 
   describe("PATCH /divisions/:id", () => {
     it("Should update a division", async () => {
       const group = await TestDataGenerator.createDummyGroup("Group Tres");
-      const division = await Division.create({ group_id: group.id, name: "Division name" });
+      const division = await Division.create({
+        group_id: group.id,
+        name: "Division name",
+      });
       const form = { name: "new name" };
 
       const response = await request(app)
@@ -107,7 +80,10 @@ describe("Division routes", () => {
 
     it("Should fail if validation fails", async () => {
       const group = await TestDataGenerator.createDummyGroup("Group");
-      const division = await Division.create({ group_id: group.id, name: "Division name" });
+      const division = await Division.create({
+        group_id: group.id,
+        name: "Division name",
+      });
       const form = { name: "s" };
 
       const response = await request(app)
@@ -121,7 +97,10 @@ describe("Division routes", () => {
   describe("DELETE /divisions/:id", () => {
     it("Should delete a division", async () => {
       const group = await TestDataGenerator.createDummyGroup("Group");
-      const division = await Division.create({ group_id: group.id, name: "Division name" });
+      const division = await Division.create({
+        group_id: group.id,
+        name: "Division name",
+      });
 
       const response = await request(app).delete(`/divisions/${division.id}`);
 

--- a/server/__tests__/routeTests/field.routes.test.js
+++ b/server/__tests__/routeTests/field.routes.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-window.setImmediate = window.setTimeout
+window.setImmediate = window.setTimeout;
 
 const TestDataGenerator = require("../../utilityFunctions/testDataGenerator.js");
 const request = require("supertest");
@@ -13,41 +13,10 @@ app.use("/field", FieldRoutes);
 app.use(Middlewares.errorHandler);
 const testDb = require("../../models");
 
-
 describe("Field Routes", () => {
-
   beforeEach(async () => {
     await testDb.Group.sync();
     await testDb.Fields.sync();
-  });
-
-  // ------------------- Get Field by Group ID Tests ----------------
-
-  it("should handle GET /getFieldByGroupId", async () => {
-    const groupM = await TestDataGenerator.createDummyGroup("Group Uno");
-
-    await testDb.Fields.create({ group_id: groupM.id, name: "SOMOS Park", address: "123 SOMOS Lane", length: 500, width: 200 });
-    await testDb.Fields.create({ group_id: groupM.id, name: "Cascarita University", address: "456 Soccer St.", length: 400, width: 150 });
-
-    const response = await request(app)
-      .get(`/field/${groupM.id}`)
-      .send();
-
-    expect(response.status).toBe(200);
-    expect(response.body.data.length).toBe(2);
-  });
-
-  it("should not get any fields with GET /getFieldByGroupId", async () => {
-    const groupM = await TestDataGenerator.createDummyGroup("Group Uno");
-
-    const response = await request(app)
-      .get(`/field/${groupM.id}`)
-      .send();
-
-    expect(response.status).toBe(500);
-    expect(response.body).toMatchObject({
-      message: "Group with given ID has no fields",
-    });
   });
 
   // ------------------- Create Tests ----------------
@@ -57,7 +26,13 @@ describe("Field Routes", () => {
 
     const response = await request(app)
       .post("/field/")
-      .send({ group_id: groupM.id, name: "SOMOS Park", address: "123 SOMOS Lane", length: 500, width: 200 });
+      .send({
+        group_id: groupM.id,
+        name: "SOMOS Park",
+        address: "123 SOMOS Lane",
+        length: 500,
+        width: 200,
+      });
 
     expect(response.status).toBe(201);
     expect(response.body).toEqual({
@@ -69,11 +44,23 @@ describe("Field Routes", () => {
   it("should not create if name is not unique POST /create", async () => {
     const groupM = await TestDataGenerator.createDummyGroup("Saul's Group");
 
-    await testDb.Fields.create({ group_id: groupM.id, name: "SOMOS Park", address: "123 SOMOS Lane", length: 500, width: 200 });
+    await testDb.Fields.create({
+      group_id: groupM.id,
+      name: "SOMOS Park",
+      address: "123 SOMOS Lane",
+      length: 500,
+      width: 200,
+    });
 
     const response = await request(app)
       .post("/field/")
-      .send({ group_id: groupM.id, name: "SOMOS Park", address: "528 Average Ave", length: 200, width: 50 });
+      .send({
+        group_id: groupM.id,
+        name: "SOMOS Park",
+        address: "528 Average Ave",
+        length: 200,
+        width: 50,
+      });
 
     expect(response.status).toBe(400);
     expect(response.body).toMatchObject({
@@ -85,11 +72,23 @@ describe("Field Routes", () => {
     const groupUno = await TestDataGenerator.createDummyGroup("Watsonville Corp.");
     const groupDos = await TestDataGenerator.createDummyGroup("Salinas Inc.");
 
-    await testDb.Fields.create({ group_id: groupUno.id, name: "SOMOS Park", address: "123 SOMOS Lane", length: 200, width: 50 });
+    await testDb.Fields.create({
+      group_id: groupUno.id,
+      name: "SOMOS Park",
+      address: "123 SOMOS Lane",
+      length: 200,
+      width: 50,
+    });
 
     const response = await request(app)
       .post("/field/")
-      .send({ group_id: groupDos.id, name: "SOMOS Park", address: "528 Average Ave", length: 200, width: 50 });
+      .send({
+        group_id: groupDos.id,
+        name: "SOMOS Park",
+        address: "528 Average Ave",
+        length: 200,
+        width: 50,
+      });
 
     expect(response.status).toBe(201);
     expect(response.body).toEqual({
@@ -102,7 +101,13 @@ describe("Field Routes", () => {
 
   it("should update field with valid ID and input PATCH /patch", async () => {
     const groupM = await TestDataGenerator.createDummyGroup("Salinas");
-    const field = await testDb.Fields.create({ group_id: groupM.id, name: "SOMOS Park", address: "123 SOMOS Lane", length: 200, width: 50 });
+    const field = await testDb.Fields.create({
+      group_id: groupM.id,
+      name: "SOMOS Park",
+      address: "123 SOMOS Lane",
+      length: 200,
+      width: 50,
+    });
 
     const updatedFieldName = "Cascarita Park";
     const response = await request(app)
@@ -116,7 +121,7 @@ describe("Field Routes", () => {
   });
 
   it("should return an error if field not found PATCH /patch", async () => {
-    const nonExistentFieldId = "9999"; 
+    const nonExistentFieldId = "9999";
 
     const response = await request(app)
       .patch(`/field/${nonExistentFieldId}`)
@@ -130,19 +135,31 @@ describe("Field Routes", () => {
 
   it("should not update if the new name is already used in the group", async () => {
     const groupM = await TestDataGenerator.createDummyGroup("Salinas");
-  
-    const field1 = await testDb.Fields.create({ group_id: groupM.id, name: "SOMOS Park", address: "123 SOMOS Lane", length: 200, width: 50 });
-    const field2 = await testDb.Fields.create({ group_id: groupM.id, name: "Cascarita University", address: "123 SOMOS Lane", length: 200, width: 50 });
-  
+
+    const field1 = await testDb.Fields.create({
+      group_id: groupM.id,
+      name: "SOMOS Park",
+      address: "123 SOMOS Lane",
+      length: 200,
+      width: 50,
+    });
+    const field2 = await testDb.Fields.create({
+      group_id: groupM.id,
+      name: "Cascarita University",
+      address: "123 SOMOS Lane",
+      length: 200,
+      width: 50,
+    });
+
     const response = await request(app)
       .patch(`/field/${field2.id}`)
       .send({ name: "SOMOS Park" });
-  
+
     expect(response.status).toBe(400);
     expect(response.body).toMatchObject({
-      message: "Name is not unique"
+      message: "Name is not unique",
     });
-  
+
     const updatedField2 = await testDb.Fields.findByPk(field2.id);
     expect(updatedField2.name).toBe("Cascarita University");
   });
@@ -151,20 +168,22 @@ describe("Field Routes", () => {
 
   it("should delete a field with a valid field ID DELETE /delete", async () => {
     const groupM = await TestDataGenerator.createDummyGroup("Salinas");
-    const field = await testDb.Fields.create({ group_id: groupM.id, name: "SOMOS Park", address: "123 SOMOS Lane", length: 200, width: 200 });
+    const field = await testDb.Fields.create({
+      group_id: groupM.id,
+      name: "SOMOS Park",
+      address: "123 SOMOS Lane",
+      length: 200,
+      width: 200,
+    });
 
-    const response = await request(app)
-      .delete(`/field/${field.id}`)
-      .send();
+    const response = await request(app).delete(`/field/${field.id}`).send();
 
     expect(response.status).toBe(204);
     expect(await testDb.Fields.findByPk(field.id)).toBeNull();
   });
 
   it("should return an error when attempting to delete a non-existant field DELETE /delete", async () => {
-    const response = await request(app)
-      .delete("/field/999")
-      .send();
+    const response = await request(app).delete("/field/999").send();
 
     expect(response.status).toBe(404);
   });

--- a/server/__tests__/routeTests/group.routes.test.js
+++ b/server/__tests__/routeTests/group.routes.test.js
@@ -31,12 +31,14 @@ const sampleErrorGroup = {
 
 describe("Integration Tests for Group", () => {
   beforeEach(async function () {
+    // await TestDb.League.sync();
     await TestDb.Division.sync();
     await TestDb.Fields.sync();
     await TestDb.Group.sync();
   });
 
   afterEach(async function () {
+    // await TestDb.League.destroy({ where: {} });
     await TestDb.Division.destroy({ where: {} });
     await TestDb.Fields.destroy({ where: {} });
     await TestDb.Group.destroy({ where: {} });
@@ -129,6 +131,31 @@ describe("Integration Tests for Group", () => {
       expect(response.status).toBe(500);
       expect(response.body).toMatchObject({
         message: "Group with given ID has no fields",
+      });
+    });
+  });
+
+  describe("GET /group/:id/leagues", () => {
+    it("should handle GET /getLeagueByGroupId", async () => {
+      const group = await TestDataGenerator.createDummyGroup("Group Uno");
+
+      await TestDb.League.create({ group_id: group.id, name: "Leeroy League" });
+      await TestDb.League.create({ group_id: group.id, name: "Martin Martians" });
+
+      const response = await request(app).get(`/group/${group.id}/leagues`).send();
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.length).toBe(2);
+    });
+
+    it("should not get any leagues with GET /getLeagueByGroupId", async () => {
+      const group = await TestDataGenerator.createDummyGroup("Group Uno");
+
+      const response = await request(app).get(`/group/${group.id}/leagues`).send();
+
+      expect(response.status).toBe(500);
+      expect(response.body).toMatchObject({
+        message: "Group with given ID has no leagues or not found",
       });
     });
   });

--- a/server/__tests__/routeTests/group.routes.test.js
+++ b/server/__tests__/routeTests/group.routes.test.js
@@ -34,6 +34,7 @@ describe("Integration Tests for Group", () => {
     // await TestDb.League.sync();
     await TestDb.Division.sync();
     await TestDb.Fields.sync();
+    await TestDb.Season.sync();
     await TestDb.Group.sync();
   });
 
@@ -41,6 +42,7 @@ describe("Integration Tests for Group", () => {
     // await TestDb.League.destroy({ where: {} });
     await TestDb.Division.destroy({ where: {} });
     await TestDb.Fields.destroy({ where: {} });
+    await TestDb.Season.destroy({ where: {} });
     await TestDb.Group.destroy({ where: {} });
   });
 

--- a/server/__tests__/routeTests/league.routes.test.js
+++ b/server/__tests__/routeTests/league.routes.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-window.setImmediate = window.setTimeout
+window.setImmediate = window.setTimeout;
 
 const TestDataGenerator = require("../../utilityFunctions/testDataGenerator.js");
 const request = require("supertest");
@@ -13,42 +13,10 @@ app.use("/league", LeagueRoutes);
 app.use(Middlewares.errorHandler);
 const testDb = require("../../models");
 
-
-
 describe("League Routes", () => {
-
   beforeEach(async () => {
     await testDb.Group.sync();
     await testDb.League.sync();
-  });
-
-  // ------------------- Get League by Group ID Tests ----------------
-
-  it("should handle GET /getLeagueByGroupId", async () => {
-    const groupM = await TestDataGenerator.createDummyGroup("Group Uno");
-
-    await testDb.League.create({ group_id: groupM.id, name: "Leeroy League" });
-    await testDb.League.create({ group_id: groupM.id, name: "Martin Martians" });
-
-    const response = await request(app)
-      .get(`/league/${groupM.id}`)
-      .send();
-
-    expect(response.status).toBe(200);
-    expect(response.body.data.length).toBe(2);
-  });
-
-  it("should not get any leagues with GET /getLeagueByGroupId", async () => {
-    const groupM = await TestDataGenerator.createDummyGroup("Group Uno");
-
-    const response = await request(app)
-      .get(`/league/${groupM.id}`)
-      .send();
-
-    expect(response.status).toBe(500);
-    expect(response.body).toMatchObject({
-      message: "Group with given ID has no leagues or not found",
-    });
   });
 
   // ------------------- Create Tests ----------------
@@ -103,7 +71,10 @@ describe("League Routes", () => {
 
   it("should update league with valid ID and input PATCH /patch", async () => {
     const groupM = await TestDataGenerator.createDummyGroup("Salinas");
-    const league = await testDb.League.create({ group_id: groupM.id, name: "SOMOS" });
+    const league = await testDb.League.create({
+      group_id: groupM.id,
+      name: "SOMOS",
+    });
 
     const updatedLeagueName = "Sopa Marucha";
     const response = await request(app)
@@ -117,7 +88,7 @@ describe("League Routes", () => {
   });
 
   it("should return an error if league not found PATCH /patch", async () => {
-    const nonExistentLeagueId = "9999"; 
+    const nonExistentLeagueId = "9999";
 
     const response = await request(app)
       .patch(`/league/${nonExistentLeagueId}`)
@@ -131,19 +102,25 @@ describe("League Routes", () => {
 
   it("should not update if the new name is already used in the group", async () => {
     const groupM = await TestDataGenerator.createDummyGroup("Salinas");
-  
-    const league1 = await testDb.League.create({ group_id: groupM.id, name: "Shrek League" });
-    const league2 = await testDb.League.create({ group_id: groupM.id, name: "Donkey League" });
-  
+
+    const league1 = await testDb.League.create({
+      group_id: groupM.id,
+      name: "Shrek League",
+    });
+    const league2 = await testDb.League.create({
+      group_id: groupM.id,
+      name: "Donkey League",
+    });
+
     const response = await request(app)
       .patch(`/league/${league2.id}`)
       .send({ name: "Shrek League" });
-  
+
     expect(response.status).toBe(500);
     expect(response.body).toMatchObject({
-      message: "Name is not unique"
+      message: "Name is not unique",
     });
-  
+
     const updatedLeague2 = await testDb.League.findByPk(league2.id);
     expect(updatedLeague2.name).toBe("Donkey League");
   });
@@ -152,20 +129,19 @@ describe("League Routes", () => {
 
   it("should delete a league with a valid league ID DELETE /delete", async () => {
     const groupM = await TestDataGenerator.createDummyGroup("Salinas");
-    const league = await testDb.League.create({ group_id: groupM.id, name: "SOMOS", });
+    const league = await testDb.League.create({
+      group_id: groupM.id,
+      name: "SOMOS",
+    });
 
-    const response = await request(app)
-      .delete(`/league/${league.id}`)
-      .send();
+    const response = await request(app).delete(`/league/${league.id}`).send();
 
     expect(response.status).toBe(204);
     expect(await testDb.League.findByPk(league.id)).toBeNull();
   });
 
   it("should return an error when attempting to delete a non-existant league DELETE /delete", async () => {
-    const response = await request(app)
-      .delete("/league/999")
-      .send();
+    const response = await request(app).delete("/league/999").send();
 
     expect(response.status).toBe(404);
   });

--- a/server/controllers/division.controller.js
+++ b/server/controllers/division.controller.js
@@ -11,11 +11,11 @@ const isDivisionNameUnique = async (groupId, name) => {
     },
   });
   return !division;
-}
+};
 
 const DivisionController = {
   getByGroupId: async function (req, res, next) {
-    const { groupId } = req.params;
+    const groupId = req.params.id;
 
     try {
       await modelByPk(res, Group, groupId);
@@ -33,7 +33,7 @@ const DivisionController = {
   create: async function (req, res, next) {
     const form = {
       group_id: req.body.group_id,
-      name: req.body.name
+      name: req.body.name,
     };
 
     try {

--- a/server/controllers/field.controller.js
+++ b/server/controllers/field.controller.js
@@ -4,7 +4,7 @@ const { Fields } = require("../models");
 
 const FieldController = function () {
   var getFieldByGroupId = async function (req, res, next) {
-    const groupId = req.params['id'];
+    const groupId = req.params.id;
 
     try {
       const result = await Fields.findAll({
@@ -35,19 +35,24 @@ const FieldController = function () {
     });
 
     return fieldFound == null;
-
   };
 
   var createField = async function (req, res, next) {
-    const { group_id, name, address, length, width } = req.body;  
-    const newField = { group_id, name, address, length, width }; 
+    const { group_id, name, address, length, width } = req.body;
+    const newField = { group_id, name, address, length, width };
 
     try {
-      const fieldFound = await isNameUniqueWithinGroup(newField.group_id, newField.name, newField.address, newField.length, newField.width);
+      const fieldFound = await isNameUniqueWithinGroup(
+        newField.group_id,
+        newField.name,
+        newField.address,
+        newField.length,
+        newField.width,
+      );
 
       if (!fieldFound) {
         res.status(400);
-        throw new Error( "Name is not unique" );
+        throw new Error("Name is not unique");
       }
 
       await Fields.build(newField).validate();
@@ -66,7 +71,7 @@ const FieldController = function () {
     try {
       let currentField = await Fields.findOne({
         where: {
-          id: req.params['id'],
+          id: req.params["id"],
         },
       });
 
@@ -75,17 +80,23 @@ const FieldController = function () {
         throw new Error("Field with given ID was not found");
       }
 
-      Object.keys(req.body).forEach(key => {
-        if (key !== "group_id"){
+      Object.keys(req.body).forEach((key) => {
+        if (key !== "group_id") {
           currentField[key] = req.body[key] ? req.body[key] : currentField[key];
         }
       });
 
-      const fieldFound = await isNameUniqueWithinGroup(currentField.group_id, currentField.name, currentField.address, currentField.length, currentField.width);
+      const fieldFound = await isNameUniqueWithinGroup(
+        currentField.group_id,
+        currentField.name,
+        currentField.address,
+        currentField.length,
+        currentField.width,
+      );
 
       if (!fieldFound) {
         res.status(400);
-        throw new Error( "Name is not unique" );
+        throw new Error("Name is not unique");
       }
 
       await currentField.validate();
@@ -101,15 +112,17 @@ const FieldController = function () {
     try {
       let deletedField = await Fields.destroy({
         where: {
-          id: req.params['id'],
+          id: req.params["id"],
         },
       });
 
       if (deletedField === 0) {
         throw new Error("No field found with the given ID");
-       }
+      }
 
-      return res.status(204).json({ success: true, message: "Delete field successfully" });
+      return res
+        .status(204)
+        .json({ success: true, message: "Delete field successfully" });
     } catch (error) {
       next(error);
     }
@@ -124,5 +137,3 @@ const FieldController = function () {
 };
 
 module.exports = FieldController();
-
-

--- a/server/controllers/league.controller.js
+++ b/server/controllers/league.controller.js
@@ -4,7 +4,7 @@ const { League } = require("../models");
 
 const LeagueController = function () {
   var getLeagueByGroupId = async function (req, res, next) {
-    const groupId = req.params['id'];
+    const groupId = req.params.id;
 
     try {
       const result = await League.findAll({
@@ -38,15 +38,18 @@ const LeagueController = function () {
   };
 
   var createLeague = async function (req, res, next) {
-    const { group_id, name, description } = req.body;  
-    const newLeague = { group_id, name, description }; 
+    const { group_id, name, description } = req.body;
+    const newLeague = { group_id, name, description };
 
     try {
-      const leagueFound = await isNameUniqueWithinGroup(newLeague.group_id, newLeague.name);
+      const leagueFound = await isNameUniqueWithinGroup(
+        newLeague.group_id,
+        newLeague.name,
+      );
 
       if (!leagueFound) {
         res.status(400);
-        throw new Error( "Name is not unique" );
+        throw new Error("Name is not unique");
       }
 
       await League.build(newLeague).validate();
@@ -65,7 +68,7 @@ const LeagueController = function () {
     try {
       let currentLeague = await League.findOne({
         where: {
-          id: req.params['id'],
+          id: req.params["id"],
         },
       });
 
@@ -74,16 +77,19 @@ const LeagueController = function () {
         throw new Error("League with given ID was not found");
       }
 
-      Object.keys(req.body).forEach(key => {
-        if (key !== "group_id"){
+      Object.keys(req.body).forEach((key) => {
+        if (key !== "group_id") {
           currentLeague[key] = req.body[key] ? req.body[key] : currentLeague[key];
-        };
+        }
       });
 
-      const leagueFound = await isNameUniqueWithinGroup(currentLeague.group_id, currentLeague.name);
+      const leagueFound = await isNameUniqueWithinGroup(
+        currentLeague.group_id,
+        currentLeague.name,
+      );
 
       if (!leagueFound) {
-        throw new Error( "Name is not unique" );
+        throw new Error("Name is not unique");
       }
 
       await currentLeague.validate();
@@ -99,15 +105,17 @@ const LeagueController = function () {
     try {
       let deletedLeague = await League.destroy({
         where: {
-          id: req.params['id'],
+          id: req.params["id"],
         },
       });
 
       if (deletedLeague === 0) {
         throw new Error("No league found with the given ID");
-       }
+      }
 
-      return res.status(204).json({ success: true, message: "Delete league successfully" });
+      return res
+        .status(204)
+        .json({ success: true, message: "Delete league successfully" });
     } catch (error) {
       next(error);
     }

--- a/server/controllers/season.controller.js
+++ b/server/controllers/season.controller.js
@@ -4,6 +4,26 @@ const { Op } = require("sequelize");
 const { League, Season } = require("../models");
 
 const SeasonController = {
+  async getSeasonByLeagueId(req, res, next) {
+    const leagueId = req.params.id;
+
+    try {
+      const league = await League.findByPk(leagueId);
+      if (!league) {
+        res.status(404);
+        throw new Error(`no such league with id ${id}`);
+      }
+      const seasons = await Season.findAll({
+        where: {
+          league_id: league.id,
+        },
+      });
+
+      res.json(seasons);
+    } catch (error) {
+      next(error);
+    }
+  },
   async getAllSeasons(req, res, next) {
     try {
       const { query } = req;
@@ -64,7 +84,7 @@ const SeasonController = {
       start_date: req.body.start_date,
       end_date: req.body.end_date,
       is_active: req.body.is_active,
-      league_id: req.body.league_id
+      league_id: req.body.league_id,
     };
 
     try {
@@ -92,7 +112,7 @@ const SeasonController = {
         throw new Error(`no such season with id ${id}`);
       }
 
-      Object.keys(req.body).forEach(key => {
+      Object.keys(req.body).forEach((key) => {
         if (key !== "league_id") {
           season[key] = req.body[key] ? req.body[key] : season[key];
         }
@@ -102,7 +122,7 @@ const SeasonController = {
       const isUnique = await isNameUniqueWithinLeague(name, league_id);
       if (!isUnique) {
         res.status(400);
-        throw new Error("name is not unique")
+        throw new Error("name is not unique");
       }
 
       await season.validate();
@@ -137,7 +157,7 @@ async function isNameUniqueWithinLeague(name, leagueId) {
     },
   });
 
-  return league === null
+  return league === null;
 }
 
 module.exports = SeasonController;

--- a/server/routes/division.routes.js
+++ b/server/routes/division.routes.js
@@ -4,7 +4,6 @@ const express = require("express");
 const DivisionController = require("../controllers/division.controller");
 const router = express.Router();
 
-router.get("/:groupId", DivisionController.getByGroupId);
 router.post("/", DivisionController.create);
 router.patch("/:id", DivisionController.update);
 router.delete("/:id", DivisionController.delete);

--- a/server/routes/field.routes.js
+++ b/server/routes/field.routes.js
@@ -5,7 +5,6 @@ const router = express.Router();
 const FieldController = require("../controllers/field.controller");
 
 router.post("/", FieldController.createField);
-router.get("/:id", FieldController.getFieldByGroupId);
 router.patch("/:id", FieldController.updateField);
 router.delete("/:id", FieldController.deleteField);
 

--- a/server/routes/group.routes.js
+++ b/server/routes/group.routes.js
@@ -4,9 +4,11 @@ const express = require("express");
 const router = express.Router();
 const GroupController = require("../controllers/group.controller");
 const DivisionController = require("../controllers/division.controller");
+const FieldController = require("../controllers/field.controller");
 
 router.get("/:id", GroupController.getGroupById);
 router.get("/:id/divisions", DivisionController.getByGroupId);
+router.get("/:id/fields", FieldController.getFieldByGroupId);
 router.post("/", GroupController.createGroup);
 router.patch("/:id", GroupController.updateGroup);
 

--- a/server/routes/group.routes.js
+++ b/server/routes/group.routes.js
@@ -5,10 +5,12 @@ const router = express.Router();
 const GroupController = require("../controllers/group.controller");
 const DivisionController = require("../controllers/division.controller");
 const FieldController = require("../controllers/field.controller");
+const LeagueController = require("../controllers/league.controller");
 
 router.get("/:id", GroupController.getGroupById);
 router.get("/:id/divisions", DivisionController.getByGroupId);
 router.get("/:id/fields", FieldController.getFieldByGroupId);
+router.get("/:id/leagues", LeagueController.getLeagueByGroupId);
 router.post("/", GroupController.createGroup);
 router.patch("/:id", GroupController.updateGroup);
 

--- a/server/routes/group.routes.js
+++ b/server/routes/group.routes.js
@@ -3,8 +3,10 @@
 const express = require("express");
 const router = express.Router();
 const GroupController = require("../controllers/group.controller");
+const DivisionController = require("../controllers/division.controller");
 
 router.get("/:id", GroupController.getGroupById);
+router.get("/:id/divisions", DivisionController.getByGroupId);
 router.post("/", GroupController.createGroup);
 router.patch("/:id", GroupController.updateGroup);
 

--- a/server/routes/league.routes.js
+++ b/server/routes/league.routes.js
@@ -3,8 +3,10 @@
 const express = require("express");
 const router = express.Router();
 const LeagueController = require("../controllers/league.controller");
+const SeasonController = require("../controllers/season.controller");
 
 router.post("/", LeagueController.createLeague);
+router.get("/:id/seasons", SeasonController.getSeasonByLeagueId);
 router.patch("/:id", LeagueController.updateLeague);
 router.delete("/:id", LeagueController.deleteLeague);
 

--- a/server/routes/league.routes.js
+++ b/server/routes/league.routes.js
@@ -5,7 +5,6 @@ const router = express.Router();
 const LeagueController = require("../controllers/league.controller");
 
 router.post("/", LeagueController.createLeague);
-router.get("/:id", LeagueController.getLeagueByGroupId);
 router.patch("/:id", LeagueController.updateLeague);
 router.delete("/:id", LeagueController.deleteLeague);
 


### PR DESCRIPTION
### Description

> [!WARNING]
> This PR introduces **breaking** changes to our API endpoints.

To maintain a clean and consistent codebase, we will need to all follow the same naming conventions and request/response structures. Here's what's new

- [x] Re-route `/resource/{groupId}` routes to `/group/{id}/resources`
- [ ] Rename all resource routes to be plural
- [ ] Remove redundant `success: true` properties from responses
- [ ] Use consistent formatting for error messages

### Issue Link

[Jira Issue](https://cascarita.atlassian.net/browse/C1-90)

### Merge Checklist

- [x] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [x] I have added test cases (if applicable)
