### PR TITLE
Chore/update group return response

### DIFF
--- a/server/__tests__/routeTests/group.routes.test.js
+++ b/server/__tests__/routeTests/group.routes.test.js
@@ -50,15 +50,17 @@ describe("Integration Tests for Group", () => {
 
   describe("GET/ Group routes", () => {
     it("successful GET of group information", async () => {
-      const coolGroup = await TestDataGenerator.createDummyGroup("Sample Group");
+      const coolGroup = await TestDataGenerator.createDummyGroup(
+        "Sample Group"
+      );
 
       const response = await request(app).get(`/groups/${coolGroup.id}`);
 
       expect(response.status).toBe(200);
-      expect(response.body.data).toEqual(
+      expect(response.body).toEqual(
         expect.objectContaining({
           name: "Sample Group",
-        }),
+        })
       );
     });
 
@@ -69,8 +71,8 @@ describe("Integration Tests for Group", () => {
       expect(response.status).toBe(500);
       expect(response.body).toEqual(
         expect.objectContaining({
-          message: "Group with given ID was not found",
-        }),
+          message: "group with given id was not found",
+        })
       );
     });
   });
@@ -121,7 +123,9 @@ describe("Integration Tests for Group", () => {
         width: 150,
       });
 
-      const response = await request(app).get(`/groups/${group.id}/fields`).send();
+      const response = await request(app)
+        .get(`/groups/${group.id}/fields`)
+        .send();
 
       expect(response.status).toBe(200);
       expect(response.body.data.length).toBe(2);
@@ -130,7 +134,9 @@ describe("Integration Tests for Group", () => {
     it("should not get any fields with GET /getFieldByGroupId", async () => {
       const group = await TestDataGenerator.createDummyGroup("Group Uno");
 
-      const response = await request(app).get(`/groups/${group.id}/fields`).send();
+      const response = await request(app)
+        .get(`/groups/${group.id}/fields`)
+        .send();
 
       expect(response.status).toBe(500);
       expect(response.body).toMatchObject({
@@ -144,9 +150,14 @@ describe("Integration Tests for Group", () => {
       const group = await TestDataGenerator.createDummyGroup("Group Uno");
 
       await TestDb.League.create({ group_id: group.id, name: "Leeroy League" });
-      await TestDb.League.create({ group_id: group.id, name: "Martin Martians" });
+      await TestDb.League.create({
+        group_id: group.id,
+        name: "Martin Martians",
+      });
 
-      const response = await request(app).get(`/groups/${group.id}/leagues`).send();
+      const response = await request(app)
+        .get(`/groups/${group.id}/leagues`)
+        .send();
 
       expect(response.status).toBe(200);
       expect(response.body.data.length).toBe(2);
@@ -155,7 +166,9 @@ describe("Integration Tests for Group", () => {
     it("should not get any leagues with GET /getLeagueByGroupId", async () => {
       const group = await TestDataGenerator.createDummyGroup("Group Uno");
 
-      const response = await request(app).get(`/groups/${group.id}/leagues`).send();
+      const response = await request(app)
+        .get(`/groups/${group.id}/leagues`)
+        .send();
 
       expect(response.status).toBe(500);
       expect(response.body).toMatchObject({
@@ -171,16 +184,18 @@ describe("Integration Tests for Group", () => {
       const response = await request(app).post("/groups/").send(sampleGroup);
 
       expect(response.status).toBe(201);
-      expect(response.body.data).toEqual(
+      expect(response.body).toEqual(
         expect.objectContaining({
           name: "Sample Group",
           city: "Sample City",
-        }),
+        })
       );
     });
 
     it("error POST when creating a new group with the same name", async () => {
-      const coolGroup = await TestDataGenerator.createDummyGroup("Sample Group");
+      const coolGroup = await TestDataGenerator.createDummyGroup(
+        "Sample Group"
+      );
 
       const response = await request(app).post("/groups/").send(sampleGroup);
 
@@ -191,7 +206,9 @@ describe("Integration Tests for Group", () => {
     });
 
     it("error POST when creating a new group with a bad state name", async () => {
-      const response = await request(app).post("/groups/").send(sampleErrorGroup);
+      const response = await request(app)
+        .post("/groups/")
+        .send(sampleErrorGroup);
 
       expect(response.status).toBe(500);
       expect(response.body).toMatchObject({

--- a/server/controllers/group.controller.js
+++ b/server/controllers/group.controller.js
@@ -2,8 +2,7 @@
 const { Group } = require("../models");
 
 const GroupController = function () {
-
-  var _getGroup = async function(id){
+  var _getGroup = async function (id) {
     let currentGroup = await Group.findOne({
       where: {
         id: id,
@@ -11,17 +10,14 @@ const GroupController = function () {
     });
 
     if (!currentGroup) {
-      throw new Error( "Group with given ID was not found" );
+      throw new Error("group with given id was not found");
     } else return currentGroup;
-  }
+  };
 
   var getGroupById = async function (req, res, next) {
     try {
-      return res.status(200).json({
-        success: true,
-        data: await _getGroup(req.params['id']),
-      });
-
+      const group = await _getGroup(req.params["id"]);
+      return res.status(200).json(group);
     } catch (error) {
       next(error);
     }
@@ -36,37 +32,28 @@ const GroupController = function () {
       zip_code: req.body.zip_code,
       logo_url: req.body.logo_url,
     };
-    
+
     try {
       await Group.build(newGroup).validate();
       const result = await Group.create(newGroup);
-
-      return res.status(201).json({
-        success: true,
-        data: result,
-      });
+      return res.status(201).json(result);
     } catch (error) {
-        next(error);
+      next(error);
     }
   };
 
   var updateGroup = async function (req, res, next) {
     try {
-      let currentGroup = await _getGroup(req.params['id'])
+      let currentGroup = await _getGroup(req.params["id"]);
 
-      Object.keys(req.body).forEach(key => {
+      Object.keys(req.body).forEach((key) => {
         currentGroup[key] = req.body[key] ? req.body[key] : currentGroup[key];
       });
-  
+
       await currentGroup.validate();
       await currentGroup.save();
-  
-      return res.status(200).json({
-        success: true,
-        data: currentGroup,
-      });
 
-
+      return res.status(200).json(currentGroup);
     } catch (error) {
       next(error);
     }

--- a/server/models/group.js
+++ b/server/models/group.js
@@ -28,10 +28,10 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false,
         validate: {
           notNull: {
-            msg: "Name field is required",
+            msg: "name field is required",
           },
           notEmpty: {
-            msg: "Name field cannot be empty",
+            msg: "name field cannot be empty",
           },
         },
       },
@@ -40,14 +40,14 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false,
         validate: {
           notNull: {
-            msg: "Street address field is required",
+            msg: "street address field is required",
           },
           notEmpty: {
-            msg: "Street address field cannot be empty",
+            msg: "street address field cannot be empty",
           },
           len: {
             args: [5, 100],
-            msg: "Street address must be between 5 and 100 characters",
+            msg: "street address must be between 5 and 100 characters",
           },
         },
       },
@@ -56,14 +56,14 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false,
         validate: {
           notNull: {
-            msg: "City field is required",
+            msg: "city field is required",
           },
           notEmpty: {
-            msg: "City field cannot be empty",
+            msg: "city field cannot be empty",
           },
           len: {
             args: [2, 50],
-            msg: "City name must be between 2 and 50 characters",
+            msg: "city name must be between 2 and 50 characters",
           },
         },
       },
@@ -72,10 +72,10 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false,
         validate: {
           notNull: {
-            msg: "State field is required",
+            msg: "state field is required",
           },
           notEmpty: {
-            msg: "State field cannot be empty",
+            msg: "state field cannot be empty",
           },
           isIn: {
             args: [
@@ -131,7 +131,7 @@ module.exports = (sequelize, DataTypes) => {
                 "WI",
                 "WY",
               ],
-            ], // Valid US state abbreviations
+            ],
             msg: "Invalid state abbreviation",
           },
         },
@@ -141,14 +141,14 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false,
         validate: {
           notNull: {
-            msg: "ZIP code field is required",
+            msg: "zip code field is required",
           },
           notEmpty: {
-            msg: "ZIP code field cannot be empty",
+            msg: "zip code field cannot be empty",
           },
           is: {
             args: /^\d{5}(-\d{4})?$/,
-            msg: "Invalid ZIP code format",
+            msg: "invalid zip code format",
           },
         },
       },


### PR DESCRIPTION
### Description

- Updated the return object of the group controller to just return the group object , no need for the `success` boolean 
- lowercased all the error messages 
- updated tests

### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Checklist

- [x] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code by running `npm run eslint`
- [x] I have added test cases (if applicable)

### Additional Notes
