### PR TITLE
Feat (Form Builder): Copy Draggable Elements + Update/Delete Forms 

### DIFF
--- a/client/assets/CopyIcon.tsx
+++ b/client/assets/CopyIcon.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+const SVGComponent = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    width={props.width}
+    height={props.height}
+    viewBox="0 0 18 17"
+    fill="none"
+    {...props}>
+    <rect
+      x={1.43555}
+      y={1.01953}
+      width={12.6348}
+      height={12.6348}
+      rx={2.25}
+      fill="white"
+      stroke={props.color}
+      strokeWidth={1.5}
+    />
+    <rect
+      x={3.92969}
+      y={3.51367}
+      width={12.6348}
+      height={12.6348}
+      rx={2.25}
+      fill="white"
+      stroke={props.color}
+      strokeWidth={1.5}
+    />
+  </svg>
+);
+export default SVGComponent;

--- a/client/components/DNDCanvas/DNDCanvas.tsx
+++ b/client/components/DNDCanvas/DNDCanvas.tsx
@@ -88,7 +88,7 @@ const DNDCanvas = forwardRef(
           }
         });
       }
-    }, [items, fields]);
+    }, [items]);
 
     const onDragEnd = (result: DropResult) => {
       if (!result.destination) return;

--- a/client/components/DNDCanvas/DNDCanvas.tsx
+++ b/client/components/DNDCanvas/DNDCanvas.tsx
@@ -16,8 +16,19 @@ import EmptyDNDCanvas from "../EmptyDNDCanvas/EmptyDNDCanvas";
 import { v4 as uuidv4 } from "uuid";
 
 const DNDCanvas = forwardRef(
-  ({ items, handleDelete, handleCopy, saveSurvey }: DNDCanvasProps, ref) => {
-    const methods = useForm<{ fields: Field[] }>();
+  (
+    {
+      items,
+      handleDelete,
+      handleCopy,
+      saveSurvey,
+      importedFields,
+    }: DNDCanvasProps,
+    ref,
+  ) => {
+    const methods = useForm<{ fields: Field[] }>({
+      defaultValues: { fields: importedFields ?? [] },
+    });
 
     useImperativeHandle(ref, () => ({
       submitForm: () => {
@@ -33,48 +44,33 @@ const DNDCanvas = forwardRef(
     };
 
     const appendField = (item: DroppedItem) => {
-      switch (item.type) {
-        case "multiple_choice":
-          append({
-            ref: item.id,
-            type: item.type,
-            title: "",
-            properties: { choices: [] },
-          });
-          break;
-        case "short_text":
-          append({
-            ref: item.id,
-            type: item.type,
-            title: "",
-            validations: {
-              max_length: 20,
-              required: false,
-            },
-          });
-          break;
-        case "dropdown":
-          append({
-            ref: item.id,
-            type: item.type,
-            title: "",
-            properties: { choices: [] },
-          });
-          break;
-        case "long_text":
-          append({
-            ref: item.id,
-            type: item.type,
-            title: "",
-            validations: {
-              max_length: 100,
-              required: false,
-            },
-          });
-          break;
-        default:
-          break;
-      }
+      const fieldTemplate = {
+        multiple_choice: {
+          ref: item.id,
+          type: item.type,
+          title: "",
+          properties: { choices: [] },
+        },
+        short_text: {
+          ref: item.id,
+          type: item.type,
+          title: "",
+          validations: { max_length: 20, required: false },
+        },
+        dropdown: {
+          ref: item.id,
+          type: item.type,
+          title: "",
+          properties: { choices: [] },
+        },
+        long_text: {
+          ref: item.id,
+          type: item.type,
+          title: "",
+          validations: { max_length: 100, required: false },
+        },
+      };
+      append(fieldTemplate[item.type]);
     };
 
     const { control, handleSubmit } = methods;
@@ -92,11 +88,7 @@ const DNDCanvas = forwardRef(
           }
         });
       }
-    }, [items]);
-
-    useEffect(() => {
-      console.log(fields);
-    }, [fields]);
+    }, [items, fields]);
 
     const onDragEnd = (result: DropResult) => {
       if (!result.destination) return;

--- a/client/components/DNDCanvas/DNDCanvas.tsx
+++ b/client/components/DNDCanvas/DNDCanvas.tsx
@@ -102,8 +102,8 @@ const DNDCanvas = forwardRef(
 
     const onCopy = (field: Field, index: number) => {
       const newRef = uuidv4();
-      const { id, ...copiedFieldWithoutId } = field; // eslint-disable-line @typescript-eslint/no-unused-vars
-      insert(index + 1, { ...copiedFieldWithoutId, ref: newRef });
+      delete field.id;
+      insert(index + 1, { ...field, ref: newRef });
       handleCopy(index, {
         id: newRef,
         type: field.type,

--- a/client/components/DNDCanvas/types.ts
+++ b/client/components/DNDCanvas/types.ts
@@ -36,6 +36,7 @@ export interface Survey {
 
 export interface DNDCanvasProps {
   items: DroppedItem[];
+  importedFields?: Field[];
   handleDelete: (name: string) => void;
   handleCopy: (index: number, copiedItem: DroppedItem) => void;
   saveSurvey: (data: Survey) => void;

--- a/client/components/DNDCanvas/types.ts
+++ b/client/components/DNDCanvas/types.ts
@@ -22,7 +22,7 @@ export interface Properties {
 
 export interface Field {
   // NOTE: See comment in DNDCanvas.tsx
-  // id: string;
+  id?: string;
   ref: string;
   type: FieldType;
   title: string;
@@ -37,5 +37,6 @@ export interface Survey {
 export interface DNDCanvasProps {
   items: DroppedItem[];
   handleDelete: (name: string) => void;
+  handleCopy: (index: number, copiedItem: DroppedItem) => void;
   saveSurvey: (data: Survey) => void;
 }

--- a/client/components/DraggableDropdown/DraggableDropdown.tsx
+++ b/client/components/DraggableDropdown/DraggableDropdown.tsx
@@ -14,6 +14,7 @@ const DraggableDropdown: React.FC<DraggableDropdownProps> = ({
   title,
   control,
   onDelete,
+  onCopy,
 }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
@@ -56,9 +57,7 @@ const DraggableDropdown: React.FC<DraggableDropdownProps> = ({
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}
-          style={{
-            ...provided.draggableProps.style,
-          }}
+          style={provided.draggableProps.style}
           onClick={handleClick}>
           <div style={{ position: "relative" }}>
             <p className={styles.textElementTypeText}>Dropdown</p>
@@ -71,6 +70,7 @@ const DraggableDropdown: React.FC<DraggableDropdownProps> = ({
                 borderRadius: 10,
               }}>
               <Controller
+                key={index}
                 name={`fields.${index}.title`}
                 control={control}
                 defaultValue={title}
@@ -95,6 +95,7 @@ const DraggableDropdown: React.FC<DraggableDropdownProps> = ({
                     marginTop: 10,
                   }}>
                   <Controller
+                    key={index}
                     name={`fields.${index}.properties.choices.${idx}.label`}
                     control={control}
                     render={({ field }) => (
@@ -132,7 +133,11 @@ const DraggableDropdown: React.FC<DraggableDropdownProps> = ({
                 <PlusCircleIcon width={20} height={20} color={"#4171ED"} />
               </button>
               {isMenuOpen && (
-                <DraggableSubMenu onDelete={onDelete} onClose={handleClick} />
+                <DraggableSubMenu
+                  onDelete={onDelete}
+                  onCopy={onCopy}
+                  onClose={handleClick}
+                />
               )}
             </div>
           </div>

--- a/client/components/DraggableDropdown/types.ts
+++ b/client/components/DraggableDropdown/types.ts
@@ -12,4 +12,5 @@ export interface DraggableDropdownProps {
   title: string;
   control: Control<{ fields: Field[] }>; // Type as appropriate
   onDelete: () => void;
+  onCopy: () => void;
 }

--- a/client/components/DraggableLongText/DraggableLongText.tsx
+++ b/client/components/DraggableLongText/DraggableLongText.tsx
@@ -11,6 +11,7 @@ const DraggableLongText: React.FC<DraggableLongTextProps> = ({
   title,
   control,
   onDelete,
+  onCopy,
 }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
@@ -25,9 +26,7 @@ const DraggableLongText: React.FC<DraggableLongTextProps> = ({
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}
-          style={{
-            ...provided.draggableProps.style,
-          }}
+          style={provided.draggableProps.style}
           onClick={handleClick}>
           <div style={{ position: "relative" }}>
             <p className={styles.textElementTypeText}>Long Text</p>
@@ -40,6 +39,7 @@ const DraggableLongText: React.FC<DraggableLongTextProps> = ({
                 borderRadius: 10,
               }}>
               <Controller
+                key={index}
                 name={`fields.${index}.title`}
                 control={control}
                 defaultValue={title} // Ensure the default value is set
@@ -55,7 +55,11 @@ const DraggableLongText: React.FC<DraggableLongTextProps> = ({
                 )}
               />
               {isMenuOpen && (
-                <DraggableSubMenu onDelete={onDelete} onClose={handleClick} />
+                <DraggableSubMenu
+                  onDelete={onDelete}
+                  onCopy={onCopy}
+                  onClose={handleClick}
+                />
               )}
             </div>
           </div>

--- a/client/components/DraggableLongText/types.ts
+++ b/client/components/DraggableLongText/types.ts
@@ -7,4 +7,5 @@ export interface DraggableLongTextProps {
   title: string;
   control: Control<{ fields: Field[] }>;
   onDelete: () => void;
+  onCopy: () => void;
 }

--- a/client/components/DraggableMultipleChoice/DraggableMultipleChoice.tsx
+++ b/client/components/DraggableMultipleChoice/DraggableMultipleChoice.tsx
@@ -14,6 +14,7 @@ const DraggableMultipleChoice: React.FC<DraggableMultipleChoiceProps> = ({
   title,
   control,
   onDelete,
+  onCopy,
 }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
@@ -41,9 +42,7 @@ const DraggableMultipleChoice: React.FC<DraggableMultipleChoiceProps> = ({
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}
-          style={{
-            ...provided.draggableProps.style,
-          }}
+          style={provided.draggableProps.style}
           onClick={handleClick}>
           <div style={{ position: "relative" }}>
             <p className={styles.textElementTypeText}>Multiple Choice</p>
@@ -86,6 +85,7 @@ const DraggableMultipleChoice: React.FC<DraggableMultipleChoiceProps> = ({
                     fill={"white"}
                   />
                   <Controller
+                    key={index}
                     name={`fields.${index}.properties.choices.${idx}.label`}
                     control={control}
                     render={({ field }) => (
@@ -116,7 +116,11 @@ const DraggableMultipleChoice: React.FC<DraggableMultipleChoiceProps> = ({
                 <PlusCircleIcon width={20} height={20} color={"#4171ED"} />
               </button>
               {isMenuOpen && (
-                <DraggableSubMenu onDelete={onDelete} onClose={handleClick} />
+                <DraggableSubMenu
+                  onDelete={onDelete}
+                  onCopy={onCopy}
+                  onClose={handleClick}
+                />
               )}
             </div>
           </div>

--- a/client/components/DraggableMultipleChoice/types.ts
+++ b/client/components/DraggableMultipleChoice/types.ts
@@ -7,4 +7,5 @@ export interface DraggableMultipleChoiceProps {
   title: string;
   control: Control<{ fields: Field[] }>; // Type as appropriate
   onDelete: () => void;
+  onCopy: () => void;
 }

--- a/client/components/DraggableShortText/DraggableShortText.tsx
+++ b/client/components/DraggableShortText/DraggableShortText.tsx
@@ -11,9 +11,9 @@ const DraggableShortText: React.FC<DraggableShortTextProps> = ({
   title,
   control,
   onDelete,
+  onCopy,
 }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-
   const handleClick = () => {
     setIsMenuOpen((prev) => !prev);
   };
@@ -25,9 +25,7 @@ const DraggableShortText: React.FC<DraggableShortTextProps> = ({
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}
-          style={{
-            ...provided.draggableProps.style,
-          }}
+          style={provided.draggableProps.style}
           onClick={handleClick}>
           <div style={{ position: "relative" }}>
             <p className={styles.textElementTypeText}>Short Text</p>
@@ -40,6 +38,7 @@ const DraggableShortText: React.FC<DraggableShortTextProps> = ({
                 borderRadius: 10,
               }}>
               <Controller
+                key={index}
                 name={`fields.${index}.title`}
                 control={control}
                 defaultValue={title} // Ensure the default value is set
@@ -56,7 +55,11 @@ const DraggableShortText: React.FC<DraggableShortTextProps> = ({
               />
             </div>
             {isMenuOpen && (
-              <DraggableSubMenu onDelete={onDelete} onClose={handleClick} />
+              <DraggableSubMenu
+                onDelete={onDelete}
+                onCopy={onCopy}
+                onClose={handleClick}
+              />
             )}
           </div>
         </div>

--- a/client/components/DraggableShortText/types.ts
+++ b/client/components/DraggableShortText/types.ts
@@ -7,4 +7,5 @@ export interface DraggableShortTextProps {
   title: string;
   control: Control<{ fields: Field[] }>;
   onDelete: () => void;
+  onCopy: () => void;
 }

--- a/client/components/DraggableSubMenu/DraggableSubMenu.tsx
+++ b/client/components/DraggableSubMenu/DraggableSubMenu.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useRef } from "react";
 import { DraggableSubMenuProps } from "./types";
 import TrashBinIcon from "../../assets/TrashBinIcon";
+import { CopyIcon } from "@radix-ui/react-icons";
 
 const DraggableSubMenu: React.FC<DraggableSubMenuProps> = ({
   onDelete,
   onClose,
+  onCopy,
 }) => {
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -26,15 +28,19 @@ const DraggableSubMenu: React.FC<DraggableSubMenuProps> = ({
       ref={menuRef}
       style={{
         display: "flex",
-        flexDirection: "row-reverse",
+        flexDirection: "column",
         position: "absolute",
         top: 0,
         right: -55,
         padding: 8,
         borderLeft: "1px solid #AAAAAA",
+        gap: 10,
       }}>
       <button type="button" onClick={onDelete}>
         <TrashBinIcon width={20} height={20} color={"#AAAAAA"} />
+      </button>
+      <button type="button" onClick={onCopy}>
+        <CopyIcon width={20} height={20} color={"#AAAAAA"} />
       </button>
     </div>
   );

--- a/client/components/DraggableSubMenu/types.ts
+++ b/client/components/DraggableSubMenu/types.ts
@@ -1,4 +1,5 @@
 export interface DraggableSubMenuProps {
   onDelete: () => void;
   onClose: () => void;
+  onCopy: () => void;
 }

--- a/client/components/DropdownMenuButton/DropdownMenuButton.tsx
+++ b/client/components/DropdownMenuButton/DropdownMenuButton.tsx
@@ -8,8 +8,9 @@ import {
 import { SlOptions } from "react-icons/sl";
 import styles from "./DropdownMenuButton.module.css";
 import { useTranslation } from "react-i18next";
+import { DropdownMenuButtonProps } from "./types";
 
-const DropdownMenuButton = () => {
+const DropdownMenuButton = ({ onEdit, onDelete }: DropdownMenuButtonProps) => {
   const { t } = useTranslation("DropdownMenuButton");
 
   return (
@@ -19,9 +20,11 @@ const DropdownMenuButton = () => {
           <SlOptions />
         </DropdownMenuTrigger>
         <DropdownMenuContent className={styles.options}>
-          <DropdownMenuItem>{t("option1")}</DropdownMenuItem>
+          <DropdownMenuItem onSelect={onEdit}>{t("option1")}</DropdownMenuItem>
           <DropdownMenuSeparator className={styles.seperator} />
-          <DropdownMenuItem>{t("option2")}</DropdownMenuItem>
+          <DropdownMenuItem onSelect={onDelete}>
+            {t("option2")}
+          </DropdownMenuItem>
           <DropdownMenuSeparator className={styles.seperator} />
           <DropdownMenuItem>{t("option3")}</DropdownMenuItem>
         </DropdownMenuContent>

--- a/client/components/DropdownMenuButton/types.ts
+++ b/client/components/DropdownMenuButton/types.ts
@@ -1,0 +1,4 @@
+export interface DropdownMenuButtonProps {
+  onEdit: () => void;
+  onDelete: () => void;
+}

--- a/client/components/Page/Page.module.css
+++ b/client/components/Page/Page.module.css
@@ -1,9 +1,11 @@
 .page {
   background-color: #fff;
   width: -webkit-fill-available;
+  width: -moz-available;
   margin-right: 35px;
   border-radius: 6px;
   height: -webkit-fill-available;
+  height: -moz-available;
   margin-bottom: 35px;
   position: fixed;
   padding: 30px;

--- a/client/pages/Forms/Forms.tsx
+++ b/client/pages/Forms/Forms.tsx
@@ -26,15 +26,36 @@ const Forms = () => {
     navigate("/forms/check");
   };
 
-  const onDelete = (id: string) => {
-    const surveys = JSON.parse(localStorage.getItem("surveys") ?? "{}");
-    delete surveys[id];
-    localStorage.setItem("surveys", JSON.stringify(surveys));
-    setForms(Object.values(surveys ?? []));
+  const onDelete = async (id: string) => {
+    try {
+      const response = await fetch(`/api/survey/${id}`, {
+        method: "DELETE",
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to delete form");
+      }
+
+      // Delete the form from local storage
+      const surveys = JSON.parse(localStorage.getItem("surveys") ?? "{}");
+      delete surveys[id];
+      localStorage.setItem("surveys", JSON.stringify(surveys));
+      setForms(Object.values(surveys ?? []));
+    } catch (error) {
+      console.error(error);
+    }
   };
 
-  const onEdit = (id: string, fields: Field[]) => {
-    navigate("/forms/check", { state: { id, fields } });
+  const onEdit = (
+    id: string,
+    title: string,
+    description: string,
+    link: string,
+    fields: Field[],
+  ) => {
+    navigate("/forms/check", {
+      state: { id, title, description, link, fields },
+    });
   };
 
   return (
@@ -73,14 +94,24 @@ const Forms = () => {
         <div>
           {forms.map((form, index) => (
             <div className={styles.cols} key={index}>
-              <p>form{index}</p>
-              <p>editsBy{index}</p>
-              <p>dates{index}</p>
+              <p>{form.title}</p>
+              <p>{form.edittedBy}</p>
+              <p>{form.lastUpdated}</p>
               <DropdownMenuButton
                 onDelete={() => onDelete(form.id)}
-                onEdit={() => onEdit(form.id, form.fields)}
+                onEdit={() =>
+                  onEdit(
+                    form.id,
+                    form.title,
+                    form.description,
+                    form.link,
+                    form.fields,
+                  )
+                }
               />
-              <ShareButton />
+              <a href={form.link} target="_blank" rel="noopener noreferrer">
+                <ShareButton />
+              </a>
             </div>
           ))}
         </div>

--- a/client/pages/Forms/Forms.tsx
+++ b/client/pages/Forms/Forms.tsx
@@ -2,24 +2,39 @@ import Page from "../../components/Page/Page";
 import Search from "../../components/Search/Search";
 import SelectMenu from "../../components/SelectMenu/SelectMenu";
 import DropdownMenuButton from "../../components/DropdownMenuButton/DropdownMenuButton";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import PrimaryButton from "../../components/PrimaryButton/PrimaryButton";
 import styles from "./Forms.module.css";
 import ShareButton from "../../components/ShareButton/ShareButton";
 import { useNavigate } from "react-router-dom";
+import { Form } from "./types";
+import { Field } from "../../components/DNDCanvas/types";
 
 const Forms = () => {
   const [sorts, setSorts] = useState("");
+  const [forms, setForms] = useState<Form[]>([]);
   const navigate = useNavigate();
 
   const sortStatuses = ["Alphabetical", "Date"];
 
-  const forms = ["form1", "form2", "form3"];
-  const editsBy = ["editBy1", "editBy2", "editBy3"];
-  const dates = ["date1", "date2", "date3"];
+  useEffect(() => {
+    const surveys = JSON.parse(localStorage.getItem("surveys") ?? "{}");
+    setForms(Object.values(surveys ?? []));
+  }, []);
 
   const handleNewFormClick = () => {
     navigate("/forms/check");
+  };
+
+  const onDelete = (id: string) => {
+    const surveys = JSON.parse(localStorage.getItem("surveys") ?? "{}");
+    delete surveys[id];
+    localStorage.setItem("surveys", JSON.stringify(surveys));
+    setForms(Object.values(surveys ?? []));
+  };
+
+  const onEdit = (id: string, fields: Field[]) => {
+    navigate("/forms/check", { state: { id, fields } });
   };
 
   return (
@@ -34,8 +49,7 @@ const Forms = () => {
               placeholder="Alphabetical"
               name="sorts"
               value={sorts}
-              onValueChange={(value) => setSorts(value)}
-            >
+              onValueChange={(value) => setSorts(value)}>
               <SelectMenu.Group>
                 {sortStatuses.map((status, idx) => (
                   <SelectMenu.Item key={idx} value={status}>
@@ -59,10 +73,13 @@ const Forms = () => {
         <div>
           {forms.map((form, index) => (
             <div className={styles.cols} key={index}>
-              <p>{form}</p>
-              <p>{editsBy[index]}</p>
-              <p>{dates[index]}</p>
-              <DropdownMenuButton />
+              <p>form{index}</p>
+              <p>editsBy{index}</p>
+              <p>dates{index}</p>
+              <DropdownMenuButton
+                onDelete={() => onDelete(form.id)}
+                onEdit={() => onEdit(form.id, form.fields)}
+              />
               <ShareButton />
             </div>
           ))}

--- a/client/pages/Forms/types.ts
+++ b/client/pages/Forms/types.ts
@@ -2,5 +2,10 @@ import { Field } from "../../components/DNDCanvas/types";
 
 export interface Form {
   id: string;
+  edittedBy: string;
+  lastUpdated: string;
+  title: string;
+  description: string;
+  link: string;
   fields: Field[];
 }

--- a/client/pages/Forms/types.ts
+++ b/client/pages/Forms/types.ts
@@ -1,0 +1,6 @@
+import { Field } from "../../components/DNDCanvas/types";
+
+export interface Form {
+  id: string;
+  fields: Field[];
+}

--- a/client/pages/Leagues/Leagues.tsx
+++ b/client/pages/Leagues/Leagues.tsx
@@ -42,8 +42,7 @@ const Leagues = () => {
               placeholder={t("filterOptions.item1")}
               name="filter"
               value={filter}
-              onValueChange={(value) => setFilter(value)}
-            >
+              onValueChange={(value) => setFilter(value)}>
               <SelectMenu.Group>
                 {filterStatuses.map((status, idx) => (
                   <SelectMenu.Item key={idx} value={status}>
@@ -59,8 +58,7 @@ const Leagues = () => {
               placeholder={t("sortOptions.item1")}
               name="sorts"
               value={sorts}
-              onValueChange={(value) => setSorts(value)}
-            >
+              onValueChange={(value) => setSorts(value)}>
               <SelectMenu.Group>
                 {sortStatuses.map((status, idx) => (
                   <SelectMenu.Item key={idx} value={status}>
@@ -82,7 +80,7 @@ const Leagues = () => {
           {leagues.map((league, index) => (
             <div className={styles.cols} key={index}>
               <p>{league}</p>
-              <DropdownMenuButton />
+              <DropdownMenuButton onDelete={() => {}} onEdit={() => {}} />
             </div>
           ))}
         </div>

--- a/client/pages/NewForm/NewForm.tsx
+++ b/client/pages/NewForm/NewForm.tsx
@@ -44,6 +44,12 @@ const NewForm = () => {
     setDroppedItems(droppedItems.filter((item) => item.id !== name));
   };
 
+  const handleCopy = (index: number, copiedItem: DroppedItem) => {
+    const updatedItems = [...droppedItems];
+    updatedItems.splice(index + 1, 0, copiedItem);
+    setDroppedItems(updatedItems);
+  };
+
   const handleSubmit = () => {
     if (canvasRef.current) {
       canvasRef.current.submitForm();
@@ -159,6 +165,7 @@ const NewForm = () => {
                   ref={canvasRef}
                   items={droppedItems}
                   handleDelete={handleDelete}
+                  handleCopy={handleCopy}
                   saveSurvey={saveSurvey}
                 />
               </div>

--- a/server/routes/survey.routes.js
+++ b/server/routes/survey.routes.js
@@ -54,4 +54,32 @@ router.delete("/survey/:id", async (req, res) => {
   }
 });
 
+router.put("/survey/:id", async (req, res) => {
+  try {
+    const response = await fetch(
+      `https://api.typeform.com/forms/${req.params.id}`,
+      {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${process.env.TYPEFORM_API_TOKEN}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(req.body),
+      },
+    );
+
+    const responseBody = await response.json();
+
+    if (!response.ok) {
+      console.error("Error updating survey:", responseBody);
+      return res.status(response.status).json(responseBody);
+    }
+
+    res.json(responseBody);
+  } catch (error) {
+    console.error("Server error:", error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
 module.exports = router;

--- a/server/routes/survey.routes.js
+++ b/server/routes/survey.routes.js
@@ -29,4 +29,29 @@ router.post("/survey", async (req, res) => {
   }
 });
 
+router.delete("/survey/:id", async (req, res) => {
+  try {
+    const response = await fetch(
+      `https://api.typeform.com/forms/${req.params.id}`,
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${process.env.TYPEFORM_API_TOKEN}`,
+        },
+      },
+    );
+
+    if (!response.ok) {
+      const responseBody = await response.json();
+      console.error("Error deleting survey:", responseBody);
+      return res.status(response.status).json(responseBody);
+    }
+
+    res.status(204).send();
+  } catch (error) {
+    console.error("Server error:", error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
### Demo

_Had to upload a crappy quality because Github only allows 10MB videos 💀_ 

https://github.com/cascaritaco/cascarita/assets/33636358/2dc95563-5151-409e-ab8d-a917c7150bc8



### Description

- Added Copy Feature: Copies draggable elements
- Added Save forms Feature: Saves forms through local storage
- Added TypeForm CRUD feature: Users can update/delete forms and it will update through TypeForm

### Issue Link

[Jira Link](https://cascarita.atlassian.net/browse/C1-99)

### Checklist

- [x] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
- Saving forms through local storage is a temp fix until the back-end + database is setup to save and retrieve form data.
