### PR TITLE
Feature/division endpoint for league modal

### DIFF
--- a/server/__tests__/routeTests/league.routes.test.js
+++ b/server/__tests__/routeTests/league.routes.test.js
@@ -1,7 +1,6 @@
 "use strict";
 
 window.setImmediate = window.setTimeout;
-window.setImmediate = window.setTimeout;
 
 const TestDataGenerator = require("../../utilityFunctions/testDataGenerator.js");
 const request = require("supertest");
@@ -144,7 +143,7 @@ it("should not create if name is not unique POST /create", async () => {
 
 it("should create a league with the same name from a different group POST /create", async () => {
   const groupUno = await TestDataGenerator.createDummyGroup(
-    "Watsonville Corp."
+    "Watsonville Corp.",
   );
   const groupDos = await TestDataGenerator.createDummyGroup("Salinas Inc.");
 
@@ -156,7 +155,7 @@ it("should create a league with the same name from a different group POST /creat
 
   expect(response.status).toBe(201);
   expect(response.body).toEqual(
-    expect.objectContaining({ name: "Summer 2024" })
+    expect.objectContaining({ name: "Summer 2024" }),
   );
 });
 
@@ -240,6 +239,25 @@ it("should return an error when attempting to delete a non-existant league DELET
 });
 
 // ------------------------------------------------
+
+it("should handle GET /getUnassociatedDivisions", async () => {
+  const session = await TestDataGenerator.createSession();
+  await TestDataGenerator.createDivision(session.groupId, "pro div");
+  const divisions = await testDb.Division.findAll({
+    where: {
+      group_id: session.groupId,
+    },
+  });
+  expect(divisions.length).toBe(2);
+
+  const response = await request(app)
+    .get(`/leagues/${session.groupId}/divisions`)
+    .send();
+  expect(response.body.length).toBe(1);
+  expect(response.body).toEqual(
+    expect.arrayContaining([expect.objectContaining({ name: "pro div" })]),
+  );
+});
 
 afterEach(async () => {
   await testDb.TeamsSession.destroy({ where: {} });

--- a/server/routes/league.routes.js
+++ b/server/routes/league.routes.js
@@ -4,10 +4,12 @@ const express = require("express");
 const router = express.Router();
 const LeagueController = require("../controllers/league.controller");
 const SeasonController = require("../controllers/season.controller");
+const DivisionController = require("../controllers/division.controller");
 
 router.post("/", LeagueController.createLeague);
 router.get("/:id", LeagueController.getLeagueByGroupId);
 router.get("/:id/seasons", SeasonController.getTeamsByLeagueId);
+router.get("/:id/divisions", DivisionController.getUnassociatedDivisions);
 router.patch("/:id", LeagueController.updateLeague);
 router.delete("/:id", LeagueController.deleteLeague);
 

--- a/server/utilityFunctions/testDataGenerator.js
+++ b/server/utilityFunctions/testDataGenerator.js
@@ -3,60 +3,81 @@
 const TestDb = require("../models");
 
 const testDataGenerator = function () {
+  const createDummyGroup = async function (groupName) {
+    let newGroupData = {
+      name: groupName,
+      street_address: "123 Main Street",
+      city: "Sample City",
+      state: "CA",
+      zip_code: "12345",
+      logo_url: "https://example.com/logo",
+    };
+    const sampleGroup = await TestDb.Group.create(newGroupData);
+    return sampleGroup;
+  };
 
-    const createDummyGroup = async function(groupName){
-        let newGroupData = {
-        name: groupName,
-        street_address: "123 Main Street",
-        city: "Sample City",
-        state: "CA",
-        zip_code: "12345",
-        logo_url: "https://example.com/logo",
-        }
-        const sampleGroup = await TestDb.Group.create(newGroupData);
-        return sampleGroup;
+  const createLeague = async function (leagueName, groupId) {
+    let newLeagueData = {
+      group_id: groupId,
+      name: leagueName,
+      description: "This is a dummy league generated for testing purposes",
+    };
+    const sampleLeague = await TestDb.League.create(newLeagueData);
+    return sampleLeague;
+  };
+
+  const createSeason = async function (
+    leagueId,
+    seasonName = "Default Season",
+    startDate = new Date(),
+    endDate = new Date(),
+    isActive = true,
+  ) {
+    let newSeasonData = {
+      name: seasonName,
+      start_date: startDate,
+      end_date: endDate,
+      is_active: isActive,
+      league_id: leagueId,
     };
 
-    const createLeague = async function(leagueName, groupId){
-        let newLeagueData = {
-            group_id: groupId,
-            name: leagueName,
-            description: "This is a dummy league generated for testing purposes",
-            }
-            const sampleLeague = await TestDb.League.create(newLeagueData);
-            return sampleLeague;
-    }
+    const sampleSeason = await TestDb.Season.create(newSeasonData);
+    return sampleSeason;
+  };
 
-    const createSeason = async function(leagueId, seasonName = "Default Season", startDate = new Date(), endDate = new Date(), isActive = true) {
-        let newSeasonData = {
-            name: seasonName,
-            start_date: startDate,
-            end_date: endDate,
-            is_active: isActive,
-            league_id: leagueId
-        };
-    
-        const sampleSeason = await TestDb.Season.create(newSeasonData);
-        return sampleSeason;
+  const createDivision = async function (
+    groupId,
+    divisionName = "Default Division",
+  ) {
+    let newDivisionData = {
+      group_id: groupId,
+      name: divisionName,
     };
 
-    const createDivision = async function(groupId, divisionName = "Default Division") {
-        let newDivisionData = {
-            group_id: groupId,
-            name: divisionName,
-        };
-    
-        const sampleDivision = await TestDb.Division.create(newDivisionData);
-        return sampleDivision;
-    };
-    
-    return {
-        createDummyGroup,
-        createLeague,
-        createSeason,
-        createDivision
-    }
+    const sampleDivision = await TestDb.Division.create(newDivisionData);
+    return sampleDivision;
+  };
 
+  const createSession = async function () {
+    const group = await createDummyGroup("soccer city");
+    const league = await createLeague("new league", group.id);
+    const season = await createSeason(league.id);
+    const division = await createDivision(group.id);
+    const session = await TestDb.Session.create({
+      division_id: division.id,
+      season_id: season.id,
+    });
+
+    return { sessionData: session, groupId: group.id };
+  };
+
+  return {
+    createDummyGroup,
+    createLeague,
+    createSeason,
+    createDivision,
+    createSession,
+  };
 };
 
 module.exports = testDataGenerator();


### PR DESCRIPTION
### Description

- The goal of this endpoint is to find all divisions that are not associated with any session. Meaning they can now be associated with a league
- if non found then it returns an empty array

### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Checklist

- [x] I have tested the changes locally by running `npm run test`
- [x] I have added or updated relevant documentation
- [x] I have autoformatted the code by running `npm run eslint`
- [x] I have added test cases (if applicable)

### Additional Notes
