### PR TITLE
feat: add utility function to parse raw responses object

### DIFF
--- a/server/utilityFunctions/responseParser.js
+++ b/server/utilityFunctions/responseParser.js
@@ -1,0 +1,523 @@
+var jsonStr = `
+{
+    "items": [
+        {
+            "landing_id": "4f7dl7beo0ktxxx0zb4f7dl3s6bh8xr7",
+            "token": "4f7dl7beo0ktxxx0zb4f7dl3s6bh8xr7",
+            "response_id": "4f7dl7beo0ktxxx0zb4f7dl3s6bh8xr7",
+            "response_type": "completed",
+            "landed_at": "2024-05-30T01:22:33Z",
+            "submitted_at": "2024-05-30T01:23:52Z",
+            "metadata": {
+                "user_agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/125.0.6422.80 Mobile/15E148 Safari/604.1",
+                "platform": "mobile",
+                "referer": "https://w15dde86k4x.typeform.com/to/TAzdWhJr",
+                "network_id": "1e520a3ecb",
+                "browser": "touch"
+            },
+            "hidden": {},
+            "calculated": {
+                "score": 0
+            },
+            "answers": [
+                {
+                    "field": {
+                        "id": "cjMxg1PHoR2J",
+                        "type": "opinion_scale",
+                        "ref": "6daafcaa-9169-484d-9c6f-dd969220d9d1"
+                    },
+                    "type": "number",
+                    "number": 5
+                },
+                {
+                    "field": {
+                        "id": "oXWOqZBmUSkv",
+                        "type": "short_text",
+                        "ref": "5aba042f-d4f3-4244-aa89-b9266a923478"
+                    },
+                    "type": "text",
+                    "text": "Leo"
+                },
+                {
+                    "field": {
+                        "id": "Gih4M0umupXH",
+                        "type": "short_text",
+                        "ref": "fcb91089-145a-4be2-887b-336cbd1c37a6"
+                    },
+                    "type": "text",
+                    "text": "Messi"
+                },
+                {
+                    "field": {
+                        "id": "U4EWp1MSbZIb",
+                        "type": "phone_number",
+                        "ref": "72c6acc6-5f80-46ce-a185-8b31f25cca99"
+                    },
+                    "type": "phone_number",
+                    "phone_number": "+14445555666"
+                },
+                {
+                    "field": {
+                        "id": "Dj2Y2CZRh21g",
+                        "type": "email",
+                        "ref": "7290045f-2547-4647-b59c-2b7c36dbcae0"
+                    },
+                    "type": "email",
+                    "email": "leo@messi.org"
+                },
+                {
+                    "field": {
+                        "id": "m1PNtmj0GW8L",
+                        "type": "short_text",
+                        "ref": "0c64a139-c9ce-4518-b3d7-220d7b599305"
+                    },
+                    "type": "text",
+                    "text": "Digital TEST"
+                },
+                {
+                    "field": {
+                        "id": "dVcUwVOUB03X",
+                        "type": "date",
+                        "ref": "4323604f-7a6b-416e-9b9a-12e341c8fecb"
+                    },
+                    "type": "date",
+                    "date": "2002-07-11T00:00:00.000Z"
+                },
+                {
+                    "field": {
+                        "id": "3fn2Yl3Ij1l9",
+                        "type": "legal",
+                        "ref": "4c2b9f54-b317-45c3-a6f6-e490c11fbd23"
+                    },
+                    "type": "boolean",
+                    "boolean": false
+                }
+            ]
+        },
+        {
+            "landing_id": "7w8jz1kdsmgyem07w8l41mp4qlxn51jk",
+            "token": "7w8jz1kdsmgyem07w8l41mp4qlxn51jk",
+            "response_id": "7w8jz1kdsmgyem07w8l41mp4qlxn51jk",
+            "response_type": "completed",
+            "landed_at": "2024-05-29T22:49:33Z",
+            "submitted_at": "2024-05-29T22:50:58Z",
+            "metadata": {
+                "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36",
+                "platform": "other",
+                "referer": "https://w15dde86k4x.typeform.com/to/TAzdWhJr",
+                "network_id": "ed7a53e54f",
+                "browser": "default"
+            },
+            "hidden": {},
+            "calculated": {
+                "score": 0
+            },
+            "answers": [
+                {
+                    "field": {
+                        "id": "cjMxg1PHoR2J",
+                        "type": "opinion_scale",
+                        "ref": "6daafcaa-9169-484d-9c6f-dd969220d9d1"
+                    },
+                    "type": "number",
+                    "number": 0
+                },
+                {
+                    "field": {
+                        "id": "oXWOqZBmUSkv",
+                        "type": "short_text",
+                        "ref": "5aba042f-d4f3-4244-aa89-b9266a923478"
+                    },
+                    "type": "text",
+                    "text": "YoYo"
+                },
+                {
+                    "field": {
+                        "id": "Gih4M0umupXH",
+                        "type": "short_text",
+                        "ref": "fcb91089-145a-4be2-887b-336cbd1c37a6"
+                    },
+                    "type": "text",
+                    "text": "Siwa"
+                },
+                {
+                    "field": {
+                        "id": "U4EWp1MSbZIb",
+                        "type": "phone_number",
+                        "ref": "72c6acc6-5f80-46ce-a185-8b31f25cca99"
+                    },
+                    "type": "phone_number",
+                    "phone_number": "+14445555888"
+                },
+                {
+                    "field": {
+                        "id": "Dj2Y2CZRh21g",
+                        "type": "email",
+                        "ref": "7290045f-2547-4647-b59c-2b7c36dbcae0"
+                    },
+                    "type": "email",
+                    "email": "yoyo@siwamail.com"
+                },
+                {
+                    "field": {
+                        "id": "m1PNtmj0GW8L",
+                        "type": "short_text",
+                        "ref": "0c64a139-c9ce-4518-b3d7-220d7b599305"
+                    },
+                    "type": "text",
+                    "text": "Pinterest"
+                },
+                {
+                    "field": {
+                        "id": "dVcUwVOUB03X",
+                        "type": "date",
+                        "ref": "4323604f-7a6b-416e-9b9a-12e341c8fecb"
+                    },
+                    "type": "date",
+                    "date": "2002-01-01T00:00:00.000Z"
+                },
+                {
+                    "field": {
+                        "id": "3fn2Yl3Ij1l9",
+                        "type": "legal",
+                        "ref": "4c2b9f54-b317-45c3-a6f6-e490c11fbd23"
+                    },
+                    "type": "boolean",
+                    "boolean": false
+                }
+            ]
+        },
+        {
+            "landing_id": "kia5m0hj5f3j4zcjoosmkia56wxhroza",
+            "token": "kia5m0hj5f3j4zcjoosmkia56wxhroza",
+            "response_id": "kia5m0hj5f3j4zcjoosmkia56wxhroza",
+            "response_type": "completed",
+            "landed_at": "2024-05-29T22:49:51Z",
+            "submitted_at": "2024-05-29T22:50:44Z",
+            "metadata": {
+                "user_agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Mobile/15E148 Safari/604.1",
+                "platform": "mobile",
+                "referer": "https://w15dde86k4x.typeform.com/to/TAzdWhJr",
+                "network_id": "ed7a53e54f",
+                "browser": "touch"
+            },
+            "hidden": {},
+            "calculated": {
+                "score": 0
+            },
+            "answers": [
+                {
+                    "field": {
+                        "id": "cjMxg1PHoR2J",
+                        "type": "opinion_scale",
+                        "ref": "6daafcaa-9169-484d-9c6f-dd969220d9d1"
+                    },
+                    "type": "number",
+                    "number": 10
+                },
+                {
+                    "field": {
+                        "id": "oXWOqZBmUSkv",
+                        "type": "short_text",
+                        "ref": "5aba042f-d4f3-4244-aa89-b9266a923478"
+                    },
+                    "type": "text",
+                    "text": "Terry"
+                },
+                {
+                    "field": {
+                        "id": "Gih4M0umupXH",
+                        "type": "short_text",
+                        "ref": "fcb91089-145a-4be2-887b-336cbd1c37a6"
+                    },
+                    "type": "text",
+                    "text": "Jones"
+                },
+                {
+                    "field": {
+                        "id": "U4EWp1MSbZIb",
+                        "type": "phone_number",
+                        "ref": "72c6acc6-5f80-46ce-a185-8b31f25cca99"
+                    },
+                    "type": "phone_number",
+                    "phone_number": "+14445555000"
+                },
+                {
+                    "field": {
+                        "id": "Dj2Y2CZRh21g",
+                        "type": "email",
+                        "ref": "7290045f-2547-4647-b59c-2b7c36dbcae0"
+                    },
+                    "type": "email",
+                    "email": "testing@icloudmail.com"
+                },
+                {
+                    "field": {
+                        "id": "m1PNtmj0GW8L",
+                        "type": "short_text",
+                        "ref": "0c64a139-c9ce-4518-b3d7-220d7b599305"
+                    },
+                    "type": "text",
+                    "text": "Cascarita "
+                },
+                {
+                    "field": {
+                        "id": "dVcUwVOUB03X",
+                        "type": "date",
+                        "ref": "4323604f-7a6b-416e-9b9a-12e341c8fecb"
+                    },
+                    "type": "date",
+                    "date": "2024-05-29T00:00:00.000Z"
+                },
+                {
+                    "field": {
+                        "id": "3fn2Yl3Ij1l9",
+                        "type": "legal",
+                        "ref": "4c2b9f54-b317-45c3-a6f6-e490c11fbd23"
+                    },
+                    "type": "boolean",
+                    "boolean": true
+                }
+            ]
+        },
+        {
+            "landing_id": "pvwyjdjitprtbyunl29pvwyjdjq9gi5a",
+            "token": "pvwyjdjitprtbyunl29pvwyjdjq9gi5a",
+            "response_id": "pvwyjdjitprtbyunl29pvwyjdjq9gi5a",
+            "response_type": "completed",
+            "landed_at": "2024-05-29T22:49:26Z",
+            "submitted_at": "2024-05-29T22:50:24Z",
+            "metadata": {
+                "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+                "platform": "other",
+                "referer": "https://w15dde86k4x.typeform.com/to/TAzdWhJr",
+                "network_id": "ed7a53e54f",
+                "browser": "default"
+            },
+            "hidden": {},
+            "calculated": {
+                "score": 0
+            },
+            "answers": [
+                {
+                    "field": {
+                        "id": "cjMxg1PHoR2J",
+                        "type": "opinion_scale",
+                        "ref": "6daafcaa-9169-484d-9c6f-dd969220d9d1"
+                    },
+                    "type": "number",
+                    "number": 0
+                },
+                {
+                    "field": {
+                        "id": "oXWOqZBmUSkv",
+                        "type": "short_text",
+                        "ref": "5aba042f-d4f3-4244-aa89-b9266a923478"
+                    },
+                    "type": "text",
+                    "text": "serg"
+                },
+                {
+                    "field": {
+                        "id": "Gih4M0umupXH",
+                        "type": "short_text",
+                        "ref": "fcb91089-145a-4be2-887b-336cbd1c37a6"
+                    },
+                    "type": "text",
+                    "text": "martial"
+                },
+                {
+                    "field": {
+                        "id": "U4EWp1MSbZIb",
+                        "type": "phone_number",
+                        "ref": "72c6acc6-5f80-46ce-a185-8b31f25cca99"
+                    },
+                    "type": "phone_number",
+                    "phone_number": "+14445556688"
+                },
+                {
+                    "field": {
+                        "id": "Dj2Y2CZRh21g",
+                        "type": "email",
+                        "ref": "7290045f-2547-4647-b59c-2b7c36dbcae0"
+                    },
+                    "type": "email",
+                    "email": "serg@martialmail.com"
+                },
+                {
+                    "field": {
+                        "id": "m1PNtmj0GW8L",
+                        "type": "short_text",
+                        "ref": "0c64a139-c9ce-4518-b3d7-220d7b599305"
+                    },
+                    "type": "text",
+                    "text": "testing text"
+                },
+                {
+                    "field": {
+                        "id": "dVcUwVOUB03X",
+                        "type": "date",
+                        "ref": "4323604f-7a6b-416e-9b9a-12e341c8fecb"
+                    },
+                    "type": "date",
+                    "date": "1111-11-11T00:00:00.000Z"
+                },
+                {
+                    "field": {
+                        "id": "3fn2Yl3Ij1l9",
+                        "type": "legal",
+                        "ref": "4c2b9f54-b317-45c3-a6f6-e490c11fbd23"
+                    },
+                    "type": "boolean",
+                    "boolean": false
+                }
+            ]
+        }
+    ],
+    "total_items": 4,
+    "page_count": 1
+}
+`
+// Following lines are acting as main for now:
+// main() {
+
+// responseIdDoc is an example of the response_ids collection
+// it should be queried/searchable by the form_id.
+var responseIdDoc = `
+{
+    "id": "asdf8jlkad7976asdf698afd",
+    "form_id": "TAzdWhJr",
+    "unique_ids": {
+    "7w8jz1kdsmgyem07w8l41mp4qlxn51jk": true,
+    "kia5m0hj5f3j4zcjoosmkia56wxhroza": true
+    }
+}
+`
+// loadMapWithDocument will load a map with any response_ids we have seen in the past
+// the map will then be used to avoid storing duplicate responses.
+uniqueResponseIds = loadMapWithDocument(responseIdDoc)
+
+// Example of how we will get the form-id from the collection:
+var sampleFormId = JSON.parse(responseIdDoc).form_id;
+
+// Call to parseResponseJSON passing in the json raw responses json to be broken into
+// individual responses, the map of responseIds we have seen in the past, and the form-id.
+var individualResponses = parseResponseJSON(jsonStr, uniqueResponseIds, sampleFormId)
+
+// Following loop is just to see what each response object looks like:
+for (var i = 0; i < individualResponses.length; i++) {
+    console.log("-------------------------")
+    var response = individualResponses[i]
+    var resStr = JSON.stringify(response, null, 4)
+    console.log(resStr)
+    console.log("-------------------------")
+}
+// }
+
+// parseResponseJSON will take in the raw responses json and break it into individual responses:
+function parseResponseJSON(jsonStr, uniqueResponseIds, formId) {
+
+    // we'll add individual responses to this array:
+    var responses = []
+
+    var obj = JSON.parse(jsonStr)
+
+    // items is a list of responses. Each response has an aswers[] and a response_id
+    var items = obj.items
+
+    // iterate through individual responses:
+    for (var i = 0; i < items.length; i++) {
+
+        let item = items[i]
+        if (item.response_type != "completed") {
+            continue;
+        }
+
+        var response_id = item.response_id;
+        var submitted_at = item.submitted_at;
+        var answers = item.answers;
+
+        // If the response_id is already in our map then it means we have already
+        // processed it in the past. We will not process it again.
+        if (uniqueResponseIds.has(response_id)) {
+            console.log("response id is already in map: ", response_id)
+            continue;
+        }
+
+        // Create individual response object and push to our responses array:
+        var response = newResponse(response_id, submitted_at, answers)
+        responses.push(response)
+
+        // maybe can set the value to the submitted date. If respnse can be updated
+        // by submitter then this can be used as indication to update the response.
+        uniqueResponseIds.set(response_id, true)
+    }
+
+    // Call function to store/update unique response ids collection with any new ones
+    // we have found:
+    storeUniqueResponseIds(uniqueResponseIds, formId)
+
+    return responses
+}
+
+// function to load collection into map:
+function loadMapWithDocument(responseIdDoc) {
+
+    // Create an empty map to store the key-value pairs
+    var map = new Map();
+
+    if (responseIdDoc.length == 0) {
+        return map
+    }
+
+    // Parse the JSON string into a JavaScript object
+    var jsonObject = JSON.parse(responseIdDoc);
+    var prevResponseIds = jsonObject.unique_ids
+
+    // Iterate over the properties of the object
+    for (var key in prevResponseIds) {
+        if (prevResponseIds.hasOwnProperty(key)) {
+            // Add each key-value pair to the map
+            map.set(key, prevResponseIds[key]);
+        }
+    }
+
+    // Return the populated map
+    return map;
+}
+
+function newResponse(response_id, submitted_at, answers) {
+    var response = {
+        response_id: response_id,
+        submitted_at: submitted_at,
+        answers: answers
+    };
+
+    return response;
+}
+
+function storeUniqueResponseIds(uniqueResponseIds, form_id) {
+    // Add logic to store response ids in a collection
+
+    /* What this collection should look like:
+        {
+            id: _ (generated collection id),
+            form_id: "string",
+            unique_ids: {
+                "string": bool,
+                "string": bool
+            }
+        }
+
+        example:
+        {
+            id: "asdf8jlkad7976asdf698afd",
+            form_id: "TAzdWhJr",
+            unique_ids: {
+                "7w8jz1kdsmgyem07w8l41mp4qlxn51jk": true,
+                "kia5m0hj5f3j4zcjoosmkia56wxhroza": true
+            }
+        }
+
+    */
+}


### PR DESCRIPTION
### Description

Adds a utility function to parse raw responses object into individual responses.
The parsing logic also includes functionality to identify duplicates (responses that have already been parsed in the past).

This utility function will later be used by the endpoint that handles retrieving individual responses and serving it to the client.

You can run the utility function by running `node server/utilityFunctions/responseParser.js`