### PR TITLE
Feature: Add GET Form endpoints 

### DIFF
--- a/client/api/forms/service.ts
+++ b/client/api/forms/service.ts
@@ -57,6 +57,7 @@ export const createForm = async (
   title: string,
   description: string,
   groupId: number | undefined,
+  userId: number | undefined,
 ) => {
   const formData = {
     title,
@@ -71,7 +72,7 @@ export const createForm = async (
     ...data,
   };
   try {
-    const response = await fetch(`/api/forms/${groupId}`, {
+    const response = await fetch(`/api/forms/${groupId}/${userId}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/client/pages/NewForm/NewForm.tsx
+++ b/client/pages/NewForm/NewForm.tsx
@@ -92,13 +92,16 @@ const NewForm = () => {
     };
 
     try {
-      const response = await fetch(`/api/forms/${currentUser?.group_id}`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
+      const response = await fetch(
+        `/api/forms/${currentUser?.group_id}/${currentUser?.id}`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(surveyData),
         },
-        body: JSON.stringify(surveyData),
-      });
+      );
       if (!response.ok) {
         throw new Error(`Error: ${response.statusText}`);
       }

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,13 @@
 import "@testing-library/jest-dom";
 import React from "react";
 global.React = React;
+
+const util = require("util");
+
+if (typeof TextEncoder === "undefined") {
+  global.TextEncoder = util.TextEncoder;
+}
+
+if (typeof TextDecoder === "undefined") {
+  global.TextDecoder = util.TextDecoder;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,8 @@
         "postcss": "^8.4.38",
         "svg-inline-loader": "^0.8.2",
         "tailwindcss": "^3.4.3",
-        "ts-jest": "^29.1.1"
+        "ts-jest": "^29.1.1",
+        "util": "^0.12.5"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -20493,6 +20494,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "postcss": "^8.4.38",
     "svg-inline-loader": "^0.8.2",
     "tailwindcss": "^3.4.3",
-    "ts-jest": "^29.1.1"
+    "ts-jest": "^29.1.1",
+    "util": "^0.12.5"
   }
 }

--- a/server/controllers/form.controller.js
+++ b/server/controllers/form.controller.js
@@ -13,19 +13,8 @@ const { Form, User } = require("../models");
 const FormController = {
   async getAllForms(req, res, next) {
     try {
-      const groupId = req.params.id;
-
-      const sqlForms = await Form.findAll({
-        where: {
-          group_id: groupId,
-        },
-        attributes: ["document_id"],
-      });
-
-      const documentIds = sqlForms.map((form) => form.document_id);
-
       const mongoForms = await FormMongo.find({
-        _id: { $in: documentIds },
+        group_id: { $in: req.params.id },
       }).select(
         "form_data.id form_data.title form_data._links.display created_by updated_by createdAt updatedAt",
       );

--- a/server/controllers/form.controller.js
+++ b/server/controllers/form.controller.js
@@ -142,8 +142,6 @@ const FormController = {
 
       const result = await form.save();
 
-      console.log("Testing the group-id thingy", req.params.group_id);
-
       const newForm = {
         group_id: req.params.group_id,
         created_by: req.params.user_id,

--- a/server/migrations/20240611200740-update-form-sql-table-add-user-columns.js
+++ b/server/migrations/20240611200740-update-form-sql-table-add-user-columns.js
@@ -8,7 +8,7 @@ module.exports = {
     try {
       await queryInterface.addColumn("Forms", "created_by", {
         type: Sequelize.INTEGER,
-        allowNull: true,
+        allowNull: false,
         references: {
           model: "Users",
           key: "id",

--- a/server/migrations/20240611200740-update-form-sql-table-add-user-columns.js
+++ b/server/migrations/20240611200740-update-form-sql-table-add-user-columns.js
@@ -1,0 +1,49 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+
+    try {
+      await queryInterface.addColumn("Forms", "created_by", {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        references: {
+          model: "Users",
+          key: "id",
+        },
+        onUpdate: "CASCADE",
+        onDelete: "CASCADE",
+        transaction,
+      });
+      await queryInterface.addColumn("Forms", "updated_by", {
+        type: Sequelize.INTEGER,
+        allowNull: true,
+        references: {
+          model: "Users",
+          key: "id",
+        },
+        onUpdate: "CASCADE",
+        onDelete: "CASCADE",
+        transaction,
+      });
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.removeColumn("Forms", "created_by", { transaction });
+      await queryInterface.removeColumn("Forms", "updated_by", { transaction });
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+};

--- a/server/models/form.js
+++ b/server/models/form.js
@@ -12,6 +12,15 @@ module.exports = (sequelize, DataTypes) => {
         foreignKey: "group_id",
         targetKey: "id",
       });
+
+      Form.belongsTo(models.User, {
+        foreignKey: "created_by",
+        targetKey: "id",
+      });
+      Form.belongsTo(models.User, {
+        foreignKey: "updated_by",
+        targetKey: "id",
+      });
     }
   }
   Form.init(
@@ -23,6 +32,14 @@ module.exports = (sequelize, DataTypes) => {
       document_id: {
         type: DataTypes.STRING,
         allowNull: false,
+      },
+      created_by: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      updated_by: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
       },
     },
     {

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -25,6 +25,16 @@ module.exports = (sequelize, DataTypes) => {
         targetKey: "id",
       });
 
+      User.hasMany(models.Form, {
+        foreignKey: "created_by",
+        sourceKey: "id",
+      });
+
+      User.hasMany(models.Form, {
+        foreignKey: "updated_by",
+        sourceKey: "id",
+      });
+
       User.hasMany(models.Games, {
         foreignKey: "created_by_id",
         sourceKey: "id",
@@ -118,7 +128,7 @@ module.exports = (sequelize, DataTypes) => {
       modelName: "User",
       createdAt: "created_at",
       updatedAt: "updated_at",
-    }
+    },
   );
 
   User.beforeCreate(async (user) => {

--- a/server/mongoModels/form.js
+++ b/server/mongoModels/form.js
@@ -19,6 +19,16 @@ const formsSchema = new Schema(
       type: Number,
       required: true,
     },
+
+    created_by: {
+      type: Schema.Types.Mixed,
+      required: true,
+    },
+
+    updated_by: {
+      type: Schema.Types.Mixed,
+      required: false,
+    },
   },
   { timestamps: true },
 );

--- a/server/routes/form.routes.js
+++ b/server/routes/form.routes.js
@@ -4,7 +4,7 @@ const express = require("express");
 const router = express.Router();
 const FormController = require("../controllers/form.controller");
 
-router.post("/:id", FormController.createForm);
+router.post("/:group_id/:user_id", FormController.createForm);
 router.get("/:form_id/responses", FormController.getResponses);
 
 module.exports = router;

--- a/server/routes/group.routes.js
+++ b/server/routes/group.routes.js
@@ -6,11 +6,13 @@ const GroupController = require("../controllers/group.controller");
 const DivisionController = require("../controllers/division.controller");
 const FieldController = require("../controllers/field.controller");
 const LeagueController = require("../controllers/league.controller");
+const FormController = require("../controllers/form.controller");
 
 router.get("/:id", GroupController.getGroupById);
 router.get("/:id/divisions", DivisionController.getByGroupId);
 router.get("/:id/fields", FieldController.getFieldByGroupId);
 router.get("/:id/leagues", LeagueController.getLeagueByGroupId);
+router.get("/:id/forms", FormController.getAllForms);
 router.post("/", GroupController.createGroup);
 router.patch("/:id", GroupController.updateGroup);
 


### PR DESCRIPTION
### Description

- route gets all the forms for a from a group id.
- update the `Forms` sql table to include user id for whoever created the form and whoever updated the form 
- need to delete all your SQL Forms data and run migrations 
- need to delete all mongo db clusters so its all in sync
- one thing to note is that we only looking up existing forms from our SQL `Forms` table , not making a GET request to typeform 

### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
