### PR TITLE
[Feat]: Rerouted Typeform get form(s) endpoints to Mongo DB

### DIFF
--- a/client/api/forms/service.ts
+++ b/client/api/forms/service.ts
@@ -3,7 +3,7 @@ import { Form, GetFormsParams } from "./types";
 // TODO: Create a call to fetch all forms by groupId
 // TODO: Start Routing to forms instead of surveys (this will be editted as more routes are called to the forms endpoint)
 
-export const getForms = async ({
+export const getTypeformForms = async ({
   page = 1,
   page_size = 10,
   search,
@@ -39,7 +39,10 @@ export const getForms = async ({
 };
 
 // fetches form data by endpoint (e.g. fetch form and/or form responses)
-export const fetchFormData = async (formId: string, endpoint: string) => {
+export const fetchTypeformFormData = async (
+  formId: string,
+  endpoint: string,
+) => {
   try {
     const response = await fetch(`/api/survey/${formId}${endpoint}`);
     if (!response.ok) {
@@ -52,7 +55,7 @@ export const fetchFormData = async (formId: string, endpoint: string) => {
   }
 };
 
-export const createForm = async (
+export const createMongoForm = async (
   data: Form,
   title: string,
   description: string,
@@ -89,7 +92,7 @@ export const createForm = async (
   }
 };
 
-export const updateForm = async (
+export const updateTypeformForm = async (
   data: Form,
   formId: string,
   title: string,
@@ -127,7 +130,7 @@ export const updateForm = async (
   }
 };
 
-export const deleteForm = async (id: string) => {
+export const deleteTypeformForm = async (id: string) => {
   try {
     const response = await fetch(`/api/survey/${id}`, {
       method: "DELETE",
@@ -138,5 +141,23 @@ export const deleteForm = async (id: string) => {
     }
   } catch (error) {
     console.error(error);
+  }
+};
+
+export const getMongoForms = async (groupId: number) => {
+  try {
+    const response = await fetch(`/api/forms/${groupId}/forms`);
+
+    const responseBody = await response.json();
+
+    if (!response.ok) {
+      console.error("Error fetching forms:", responseBody);
+      throw new Error(`Error fetching forms: ${response.statusText}`);
+    }
+
+    return responseBody;
+  } catch (error) {
+    console.error("Server error:", error);
+    throw error;
   }
 };

--- a/client/api/forms/service.ts
+++ b/client/api/forms/service.ts
@@ -148,16 +148,13 @@ export const getMongoForms = async (groupId: number) => {
   try {
     const response = await fetch(`/api/forms/${groupId}/forms`);
 
-    const responseBody = await response.json();
-
     if (!response.ok) {
-      console.error("Error fetching forms:", responseBody);
       throw new Error(`Error fetching forms: ${response.statusText}`);
     }
 
-    return responseBody;
+    return response.json();
   } catch (error) {
-    console.error("Server error:", error);
+    console.error("Error fetching forms:", error);
     throw error;
   }
 };
@@ -166,16 +163,28 @@ export const getMongoFormById = async (formId: string) => {
   try {
     const response = await fetch(`/api/forms/${formId}`);
 
-    const responseBody = await response.json();
-
     if (!response.ok) {
-      console.error("Error fetching form:", responseBody);
       throw new Error(`Error fetching form: ${response.statusText}`);
     }
 
-    return responseBody;
+    return response.json();
   } catch (error) {
-    console.error("Server error:", error);
+    console.error("Error fetching forms:", error);
+    throw error;
+  }
+};
+
+export const getMongoFormResponses = async (formId: string) => {
+  try {
+    const response = await fetch(`/api/forms/${formId}/responses`);
+
+    if (!response.ok) {
+      throw new Error(`Error fetching form responses: ${response.statusText}`);
+    }
+
+    return response.json();
+  } catch (error) {
+    console.error("Error fetching responses:", error);
     throw error;
   }
 };

--- a/client/api/forms/service.ts
+++ b/client/api/forms/service.ts
@@ -55,43 +55,6 @@ export const fetchTypeformFormData = async (
   }
 };
 
-export const createMongoForm = async (
-  data: Form,
-  title: string,
-  description: string,
-  groupId: number | undefined,
-  userId: number | undefined,
-) => {
-  const formData = {
-    title,
-    welcome_screens: [
-      {
-        title,
-        properties: {
-          description,
-        },
-      },
-    ],
-    ...data,
-  };
-  try {
-    const response = await fetch(`/api/forms/${groupId}/${userId}`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(formData),
-    });
-    if (!response.ok) {
-      throw new Error(`Error: ${response.statusText}`);
-    }
-
-    return response.json();
-  } catch (err) {
-    console.error("Error creating form:", err);
-  }
-};
-
 export const updateTypeformForm = async (
   data: Form,
   formId: string,
@@ -144,6 +107,43 @@ export const deleteTypeformForm = async (id: string) => {
   }
 };
 
+export const createMongoForm = async (
+  data: Form,
+  title: string,
+  description: string,
+  groupId: number | undefined,
+  userId: number | undefined,
+) => {
+  const formData = {
+    title,
+    welcome_screens: [
+      {
+        title,
+        properties: {
+          description,
+        },
+      },
+    ],
+    ...data,
+  };
+  try {
+    const response = await fetch(`/api/forms/${groupId}/${userId}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(formData),
+    });
+    if (!response.ok) {
+      throw new Error(`Error: ${response.statusText}`);
+    }
+
+    return response.json();
+  } catch (err) {
+    console.error("Error creating form:", err);
+  }
+};
+
 export const getMongoForms = async (groupId: number) => {
   try {
     const response = await fetch(`/api/forms/${groupId}/forms`);
@@ -153,6 +153,24 @@ export const getMongoForms = async (groupId: number) => {
     if (!response.ok) {
       console.error("Error fetching forms:", responseBody);
       throw new Error(`Error fetching forms: ${response.statusText}`);
+    }
+
+    return responseBody;
+  } catch (error) {
+    console.error("Server error:", error);
+    throw error;
+  }
+};
+
+export const getMongoFormById = async (formId: string) => {
+  try {
+    const response = await fetch(`/api/forms/${formId}`);
+
+    const responseBody = await response.json();
+
+    if (!response.ok) {
+      console.error("Error fetching form:", responseBody);
+      throw new Error(`Error fetching form: ${response.statusText}`);
     }
 
     return responseBody;

--- a/client/api/forms/service.ts
+++ b/client/api/forms/service.ts
@@ -24,17 +24,14 @@ export const getTypeformForms = async ({
     const queryParams = new URLSearchParams(params).toString();
     const response = await fetch(`/api/surveys?${queryParams}`);
 
-    const responseBody = await response.json();
-
     if (!response.ok) {
-      console.error("Error fetching forms:", responseBody);
       throw new Error(`Error fetching forms: ${response.statusText}`);
     }
 
-    return responseBody;
-  } catch (error) {
-    console.error("Server error:", error);
-    throw error;
+    return response.json();
+  } catch (err) {
+    console.error("Error fetching forms:", err);
+    throw err;
   }
 };
 
@@ -45,13 +42,15 @@ export const fetchTypeformFormData = async (
 ) => {
   try {
     const response = await fetch(`/api/survey/${formId}${endpoint}`);
+
     if (!response.ok) {
       throw new Error(`Error fetching data: ${response.statusText}`);
     }
+
     return response.json();
-  } catch (error) {
-    console.error("Error fetching form data:", error);
-    throw error;
+  } catch (err) {
+    console.error("Error fetching form data:", err);
+    throw err;
   }
 };
 
@@ -88,8 +87,9 @@ export const updateTypeformForm = async (
     }
 
     return response.json();
-  } catch (error) {
-    console.error(error);
+  } catch (err) {
+    console.error("Error updating form:", err);
+    throw err;
   }
 };
 
@@ -102,8 +102,9 @@ export const deleteTypeformForm = async (id: string) => {
     if (!response.ok) {
       throw new Error("Failed to delete form");
     }
-  } catch (error) {
-    console.error(error);
+  } catch (err) {
+    console.error("Error deleting form:", err);
+    throw err;
   }
 };
 
@@ -141,6 +142,7 @@ export const createMongoForm = async (
     return response.json();
   } catch (err) {
     console.error("Error creating form:", err);
+    throw err;
   }
 };
 
@@ -153,9 +155,9 @@ export const getMongoForms = async (groupId: number) => {
     }
 
     return response.json();
-  } catch (error) {
-    console.error("Error fetching forms:", error);
-    throw error;
+  } catch (err) {
+    console.error("Error fetching forms:", err);
+    throw err;
   }
 };
 
@@ -168,9 +170,9 @@ export const getMongoFormById = async (formId: string) => {
     }
 
     return response.json();
-  } catch (error) {
-    console.error("Error fetching forms:", error);
-    throw error;
+  } catch (err) {
+    console.error("Error fetching form:", err);
+    throw err;
   }
 };
 
@@ -183,8 +185,8 @@ export const getMongoFormResponses = async (formId: string) => {
     }
 
     return response.json();
-  } catch (error) {
-    console.error("Error fetching responses:", error);
-    throw error;
+  } catch (err) {
+    console.error("Error fetching responses:", err);
+    throw err;
   }
 };

--- a/client/components/FormResponses/FormResponses.tsx
+++ b/client/components/FormResponses/FormResponses.tsx
@@ -7,7 +7,10 @@ import {
   FormResponsesProps,
   TypeformResponse,
 } from "./types";
-import { fetchTypeformFormData } from "../../api/forms/service";
+import {
+  fetchTypeformFormData,
+  getMongoFormById,
+} from "../../api/forms/service";
 import { truncateText } from "../../util/truncateText";
 import { useTranslation } from "react-i18next";
 
@@ -20,9 +23,16 @@ const FormResponses = ({ formId }: FormResponsesProps) => {
 
   useEffect(() => {
     (async () => {
-      const formData = await fetchTypeformFormData(formId, "");
-      setFormFields(formData.fields);
-      const responsesData = await fetchTypeformFormData(formId, "/responses");
+      const formData = await getMongoFormById(formId);
+      // TODO: Backend should return a form, not an array of forms
+      if (formData[0] == null) {
+        throw new Error("Form not found");
+      }
+      setFormFields(formData[0].form_data.fields);
+      const responsesData = await fetchTypeformFormData(
+        formData[0].form_data.id,
+        "/responses",
+      );
       const responsesMap = responsesData.items.reduce(
         (res: AnswerRecordMap, response: TypeformResponse) => {
           const answersMap: Map<string, Answer> = new Map();

--- a/client/components/FormResponses/FormResponses.tsx
+++ b/client/components/FormResponses/FormResponses.tsx
@@ -7,7 +7,7 @@ import {
   FormResponsesProps,
   TypeformResponse,
 } from "./types";
-import { fetchFormData } from "../../api/forms/service";
+import { fetchTypeformFormData } from "../../api/forms/service";
 import { truncateText } from "../../util/truncateText";
 import { useTranslation } from "react-i18next";
 
@@ -20,9 +20,9 @@ const FormResponses = ({ formId }: FormResponsesProps) => {
 
   useEffect(() => {
     (async () => {
-      const formData = await fetchFormData(formId, "");
+      const formData = await fetchTypeformFormData(formId, "");
       setFormFields(formData.fields);
-      const responsesData = await fetchFormData(formId, "/responses");
+      const responsesData = await fetchTypeformFormData(formId, "/responses");
       const responsesMap = responsesData.items.reduce(
         (res: AnswerRecordMap, response: TypeformResponse) => {
           const answersMap: Map<string, Answer> = new Map();

--- a/client/pages/Forms/Forms.tsx
+++ b/client/pages/Forms/Forms.tsx
@@ -9,19 +9,26 @@ import ShareButton from "../../components/ShareButton/ShareButton";
 import { useNavigate } from "react-router-dom";
 import { Form } from "./types";
 import { useTranslation } from "react-i18next";
-import { deleteForm, fetchFormData, getForms } from "../../api/forms/service";
+import {
+  deleteTypeformForm,
+  fetchTypeformFormData,
+  getTypeformForms,
+  getMongoForms,
+} from "../../api/forms/service";
+import { useAuth } from "../../components/AuthContext/AuthContext";
 
 const Forms = () => {
   const { t } = useTranslation("Forms");
   const [sorts, setSorts] = useState("");
   const [forms, setForms] = useState<Form[]>([]);
   const navigate = useNavigate();
-
+  const { currentUser } = useAuth();
   const sortStatuses = [t("sortOptions.item1"), t("sortOptions.item2")];
 
   useEffect(() => {
     (async () => {
-      const fetchedForms = await getForms();
+      const fetchedForms = await getTypeformForms();
+      console.log(getMongoForms(currentUser?.group_id ?? -1));
       setForms(fetchedForms.items ?? []);
     })();
   }, []);
@@ -31,12 +38,12 @@ const Forms = () => {
   };
 
   const onDelete = async (id: string) => {
-    await deleteForm(id);
+    await deleteTypeformForm(id);
     setForms((forms) => forms.filter((form) => form.id !== id));
   };
 
   const onEdit = async (id: string) => {
-    const form = await fetchFormData(id, "");
+    const form = await fetchTypeformFormData(id, "");
     navigate("/forms/check", {
       state: {
         id,

--- a/client/pages/Forms/Forms.tsx
+++ b/client/pages/Forms/Forms.tsx
@@ -27,7 +27,6 @@ const Forms = () => {
   useEffect(() => {
     (async () => {
       const mongoForms = await getMongoForms(currentUser?.group_id ?? -1);
-      console.log(mongoForms);
       setForms(mongoForms);
     })();
   }, []);

--- a/client/pages/Forms/types.ts
+++ b/client/pages/Forms/types.ts
@@ -1,5 +1,3 @@
-import { Field } from "../../components/DNDCanvas/types";
-
 export interface WelcomeScreen {
   id: string;
   ref: string;
@@ -12,15 +10,25 @@ export interface WelcomeScreen {
 }
 
 export interface Form {
-  id: string;
-  editedBy: string;
-  last_updated_at: string;
-  title: string;
-  description: string;
-  welcome_screens: WelcomeScreen[];
-  fields: Field[];
-  _links: {
-    display: string;
-    responses: string;
+  _id: string;
+  created_by: {
+    id: string;
+    first_name: string;
+    last_name: string;
+  };
+  updated_by: {
+    id: string;
+    first_name: string;
+    last_name: string;
+  };
+  createdAt: Date;
+  updatedAt: Date;
+  form_data: {
+    id: string;
+    title: string;
+    _links: {
+      display: string;
+      responses: string;
+    };
   };
 }

--- a/client/pages/NewForm/NewForm.tsx
+++ b/client/pages/NewForm/NewForm.tsx
@@ -11,7 +11,7 @@ import { useAuth } from "../../components/AuthContext/AuthContext";
 import { useTranslation } from "react-i18next";
 import FormResponses from "../../components/FormResponses/FormResponses";
 import { toSnakeCase } from "../../util/toSnakeCase";
-import { createForm, updateForm } from "../../api/forms/service";
+import { createMongoForm, updateTypeformForm } from "../../api/forms/service";
 
 const NewForm = () => {
   const { t } = useTranslation("NewForms");
@@ -78,7 +78,7 @@ const NewForm = () => {
   };
 
   const onCreate = async (data: Form) => {
-    const response = await createForm(
+    const response = await createMongoForm(
       data,
       title,
       description,
@@ -94,7 +94,7 @@ const NewForm = () => {
     if (formId == null || formId === undefined) {
       throw new Error("Form ID is undefined");
     }
-    const response = await updateForm(data, formId, title, description);
+    const response = await updateTypeformForm(data, formId, title, description);
     setFields(response.fields);
   };
 

--- a/server/routes/form.routes.js
+++ b/server/routes/form.routes.js
@@ -7,5 +7,5 @@ const FormController = require("../controllers/form.controller");
 router.post("/:group_id/:user_id", FormController.createForm);
 router.get("/:form_id/responses", FormController.getResponses);
 router.get("/:document_id", FormController.getFormByDocumentId);
-
+router.get("/:id/forms", FormController.getAllForms);
 module.exports = router;


### PR DESCRIPTION
- feat(form routes): Added Mongo API call to get all forms and seperated Typeform Logic from Mongo API calls
- feat(routing): API routes to mongo for fetching forms and forms by id
- feat(responses): Added fetch form fields through our mongo db endpoint

### Description

Re-routed some of the typeform calls to our mongo db calls

### Issue Link

[Jira Link](https://cascarita.atlassian.net/browse/C1-99)

### Checklist

- [x] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)
###  Extra Notes:
- **The Backend does need a lot of refactor, as there's a a lot usage of  `Schema.Types.Mixed` being used, and fetching the data is creating a lot of bugs when we don't know what data we're receiving (currently fetching form by id is returning an array instead of the form itself). I do assume these will get changed when we move away from typeform's api calls 😃 .**

## Breaking Changes
- Since we do not have Update/Delete endpoints, the Delete / New Form Save will be broken
- I was going to implement get Responses but this API has bugs currently, so I resorted to using Typeform responses API call. #82 is the issue.
