### PR TITLE
[Feat]: Responses routing to our Mongo DB + onCreate Bug Fix + Retrieving Form by Id Refactor

### DIFF
--- a/client/components/FormResponses/FormResponses.tsx
+++ b/client/components/FormResponses/FormResponses.tsx
@@ -4,12 +4,12 @@ import {
   Answer,
   AnswerRecordMap,
   Field,
+  FormResponse,
   FormResponsesProps,
-  TypeformResponse,
 } from "./types";
 import {
-  fetchTypeformFormData,
   getMongoFormById,
+  getMongoFormResponses,
 } from "../../api/forms/service";
 import { truncateText } from "../../util/truncateText";
 import { useTranslation } from "react-i18next";
@@ -28,22 +28,24 @@ const FormResponses = ({ formId }: FormResponsesProps) => {
       if (formData[0] == null) {
         throw new Error("Form not found");
       }
+
       setFormFields(formData[0].form_data.fields);
-      const responsesData = await fetchTypeformFormData(
+      const responsesData = await getMongoFormResponses(
         formData[0].form_data.id,
-        "/responses",
       );
-      const responsesMap = responsesData.items.reduce(
-        (res: AnswerRecordMap, response: TypeformResponse) => {
+      const responsesMap = responsesData.reduce(
+        (result: AnswerRecordMap, res: FormResponse) => {
           const answersMap: Map<string, Answer> = new Map();
-          response.answers?.forEach((answer: Answer) => {
+          res.response.answers?.forEach((answer: Answer) => {
+            console.log(answer);
             answersMap.set(answer.field.id, answer);
           });
-          res.set(response.response_id, answersMap);
-          return res;
+          result.set(res.response.response_id, answersMap);
+          return result;
         },
         new Map(),
       );
+
       setFormResponsesMap(responsesMap);
     })();
   }, [formId]);

--- a/client/components/FormResponses/FormResponses.tsx
+++ b/client/components/FormResponses/FormResponses.tsx
@@ -24,20 +24,13 @@ const FormResponses = ({ formId }: FormResponsesProps) => {
   useEffect(() => {
     (async () => {
       const formData = await getMongoFormById(formId);
-      // TODO: Backend should return a form, not an array of forms
-      if (formData[0] == null) {
-        throw new Error("Form not found");
-      }
 
-      setFormFields(formData[0].form_data.fields);
-      const responsesData = await getMongoFormResponses(
-        formData[0].form_data.id,
-      );
+      setFormFields(formData.form_data.fields);
+      const responsesData = await getMongoFormResponses(formData.form_data.id);
       const responsesMap = responsesData.reduce(
         (result: AnswerRecordMap, res: FormResponse) => {
           const answersMap: Map<string, Answer> = new Map();
           res.response.answers?.forEach((answer: Answer) => {
-            console.log(answer);
             answersMap.set(answer.field.id, answer);
           });
           result.set(res.response.response_id, answersMap);

--- a/client/components/FormResponses/types.ts
+++ b/client/components/FormResponses/types.ts
@@ -42,6 +42,12 @@ export interface TypeformResponse {
   answers: Answer[];
 }
 
+export interface FormResponse {
+  _id: string;
+  form_id: string;
+  response: TypeformResponse;
+}
+
 // Responses data type representing the structure of the response data object from Typeform
 export interface TypeformResponsesData {
   items: TypeformResponse[];

--- a/client/pages/Forms/Forms.tsx
+++ b/client/pages/Forms/Forms.tsx
@@ -43,19 +43,14 @@ const Forms = () => {
   const onEdit = async (id: string) => {
     const form = await getMongoFormById(id);
 
-    // TODO: Backend should return a form, not an array of forms
-    if (form[0] == null) {
-      throw new Error("Form not found");
-    }
-
     navigate("/forms/check", {
       state: {
         id,
-        title: form[0].form_data.title,
+        title: form.form_data.title,
         description:
-          form[0].form_data.welcome_screens?.[0]?.properties?.description ?? "",
-        link: form[0].form_data._links.display,
-        fields: form[0].form_data.fields,
+          form.form_data.welcome_screens?.[0]?.properties?.description ?? "",
+        link: form.form_data._links.display,
+        fields: form.form_data.fields,
       },
     });
   };

--- a/client/pages/NewForm/NewForm.tsx
+++ b/client/pages/NewForm/NewForm.tsx
@@ -86,7 +86,7 @@ const NewForm = () => {
       currentUser?.id,
     );
     setFormLink(response.form_data._links.display);
-    setFormId(response.form_data.id);
+    setFormId(response._id);
     setFields(response.form_data.fields);
   };
 

--- a/server/controllers/form.controller.js
+++ b/server/controllers/form.controller.js
@@ -160,9 +160,7 @@ const FormController = {
 
   async getFormByDocumentId(req, res, next) {
     try {
-      const results = await FormMongo.find({
-        _id: req.params.document_id,
-      });
+      const results = await FormMongo.findById(req.params.document_id);
 
       return res.status(201).json(results);
     } catch (error) {


### PR DESCRIPTION
- feat(responses route): Responses routes are being routed to mongodb instead of typeform
- fix(fetching form): Fetching form by ID returns a single document
- fix(onCreate form): onCreate sets mongo db form id instead of typeform id

### Description

Rerouted fetching responses to our backend, this is our last route for the demo and the only thing missing for Issue #78  is updating / deleting forms (but this will be added later).

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes

N/A
