### PR TITLE
Fix: fixes duplicate individual form responses

### DIFF
--- a/server/utilityFunctions/responseParser.js
+++ b/server/utilityFunctions/responseParser.js
@@ -81,6 +81,8 @@ function newResponse(response_id, submitted_at, answers) {
 }
 
 async function storeUniqueResponseIds(uniqueResponseIds, form_id, emptyMap) {
+  var new_responses = uniqueResponseIds.size != 0;
+
   const response_id = new ResponseId({
     form_id: form_id,
     unique_ids: uniqueResponseIds,
@@ -90,7 +92,9 @@ async function storeUniqueResponseIds(uniqueResponseIds, form_id, emptyMap) {
     form_id: form_id,
   });
 
-  if (emptyMap) {
+  if (emptyMap && !new_responses) {
+    return
+  } else if (emptyMap && new_responses) {
     const responseResult = await response_id.save();
   } else {
     const responseResult = await ResponseId.updateOne(


### PR DESCRIPTION
### Description
This PR fixes the issue where individual form responses were being duplicated.

Fix:
- Adds check to ensure that if we have no new responses we do not create an empty responseids document.

<!-- Provide a brief description of the changes introduced by this pull request -->

### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Checklist

- [x] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
