### PR TITLE
fix: adjust z-index for top nav

### DIFF
--- a/client/components/TopNav/TopNav.module.css
+++ b/client/components/TopNav/TopNav.module.css
@@ -84,7 +84,6 @@
   background-color: #fff;
   height: 80px;
   box-shadow: 1px 1px 2px rgba(0, 0, 0.1, 0.1);
-  z-index: 6;
 }
 
 .button-container {


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes introduced by this pull request -->
TopNavBar would still show even when modal popped up. Removing z-index solves the problem.


https://github.com/cascaritaco/cascarita/assets/32311654/76855d0c-64e4-4d19-902b-de902c635b4a


### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Checklist

- [X] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
