### PR TITLE
fix: correct z-index to show language options

### DIFF
--- a/client/components/LanguageDropdown/LanguageDropdown.module.css
+++ b/client/components/LanguageDropdown/LanguageDropdown.module.css
@@ -1,6 +1,5 @@
 .languageDropdown {
   position: fixed;
-  z-index: 2;
   top: 55px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   background-color: white;

--- a/client/components/LanguageDropdown/LanguageDropdown.tsx
+++ b/client/components/LanguageDropdown/LanguageDropdown.tsx
@@ -25,7 +25,15 @@ const LanguageDropdown: React.FC<LanguageDropdownProps> = ({
     if (currLanguage) {
       setSelectedLanguage(currLanguage);
     }
-  }, []);
+
+    const timeout = setTimeout(() => {
+      handleSelect();
+    }, 5000);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [handleSelect]);
 
   const handleLanguageChange = async (
     event: React.ChangeEvent<HTMLInputElement>,

--- a/client/components/LanguagePreferenceButton/LanguagePreferenceButton.tsx
+++ b/client/components/LanguagePreferenceButton/LanguagePreferenceButton.tsx
@@ -9,10 +9,14 @@ const LanguagePreferenceButton = () => {
     setShowDropdown(!showDropdown);
   };
 
+  const handleSelect = () => {
+    setShowDropdown(false);
+  };
+
   return (
     <div>
       <TfiWorld onClick={handleIconClick} style={{ cursor: "pointer" }} />
-      {showDropdown && <LanguageDropdown handleSelect={handleIconClick} />}
+      {showDropdown && <LanguageDropdown handleSelect={handleSelect} />}
     </div>
   );
 };

--- a/client/components/Modal/Modal.module.css
+++ b/client/components/Modal/Modal.module.css
@@ -46,6 +46,7 @@
 
 .overlay[data-state="open"] {
   animation: dialog-overlay-show 200ms;
+  z-index: 2;
 }
 
 .overlay[data-state="closed"] {
@@ -68,6 +69,7 @@
 
 .content[data-state="open"] {
   animation: dialog-content-show 200ms;
+  z-index: 2;
 }
 
 .content[data-state="closed"] {

--- a/client/components/TopNav/TopNav.module.css
+++ b/client/components/TopNav/TopNav.module.css
@@ -78,6 +78,7 @@
 }
 
 .top-nav {
+  z-index: 1;
   display: flex;
   position: fixed;
   width: 100%;


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes introduced by this pull request -->
Although the z-index bug was fixed in #90 , it conflated with showing the `LanguageDropDown` component so that it would not show. That has been corrected. Also timeout was added to the `LanguageDropDown` to stop showing if no activity to select a language was made over the last 5 seconds.

https://github.com/cascaritaco/cascarita/assets/32311654/f74bce89-9a9d-4aac-a5ee-60ca541cfa54


### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Checklist

- [X] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [ ] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
