### PR TITLE
[Feat]: Added multi selection for form builder

### DIFF
--- a/client/components/DragAndDropComponents/DNDCanvas/DNDCanvas.tsx
+++ b/client/components/DragAndDropComponents/DNDCanvas/DNDCanvas.tsx
@@ -52,7 +52,7 @@ const DNDCanvas = forwardRef(
         multiple_choice: {
           title: "",
           ref: item.id,
-          properties: { choices: [] },
+          properties: { choices: [], allow_multiple_selection: false },
           validations: { required: false },
           type: item.type,
         },
@@ -138,6 +138,11 @@ const DNDCanvas = forwardRef(
         `fields.${index + 1}.validations`,
         methods.getValues(`fields.${index}.validations`),
       );
+
+      methods.setValue(
+        `fields.${index + 1}.properties`,
+        methods.getValues(`fields.${index}.properties`),
+      );
     };
 
     const onSubmit = (data: Form) => {
@@ -174,7 +179,8 @@ const DNDCanvas = forwardRef(
                           index={index}
                           title={field.title}
                           validations={field.validations}
-                          control={methods.control}
+                          properties={field.properties}
+                          control={control}
                           onDelete={() => onDelete(index, field.ref)}
                           onCopy={() => onCopy(field, index)}
                         />

--- a/client/components/DragAndDropComponents/DNDCanvas/types.ts
+++ b/client/components/DragAndDropComponents/DNDCanvas/types.ts
@@ -20,6 +20,7 @@ export interface Label {
 
 export interface Properties {
   choices?: Label[];
+  allow_multiple_selection?: boolean;
   default_country_code?: string;
 }
 

--- a/client/components/DragAndDropComponents/DraggableDropdown/types.ts
+++ b/client/components/DragAndDropComponents/DraggableDropdown/types.ts
@@ -1,5 +1,5 @@
 import { Control } from "react-hook-form";
-import { Field, Validation } from "../DNDCanvas/types";
+import { Field, Properties, Validation } from "../DNDCanvas/types";
 
 export interface Option {
   ref: string;
@@ -10,6 +10,7 @@ export interface DraggableDropdownProps {
   id: string;
   index: number;
   validations: Validation | undefined;
+  properties: Properties | undefined;
   title: string;
   control: Control<{ fields: Field[] }>; // Type as appropriate
   onDelete: () => void;

--- a/client/components/DragAndDropComponents/DraggableEmail/types.ts
+++ b/client/components/DragAndDropComponents/DraggableEmail/types.ts
@@ -1,11 +1,12 @@
 import { Control } from "react-hook-form";
-import { Field, Validation } from "../DNDCanvas/types";
+import { Field, Properties, Validation } from "../DNDCanvas/types";
 
 export interface DraggableEmailProps {
   id: string;
   index: number;
   title: string;
   validations: Validation | undefined;
+  properties: Properties | undefined;
   control: Control<{ fields: Field[] }>;
   onDelete: () => void;
   onCopy: () => void;

--- a/client/components/DragAndDropComponents/DraggableLongText/types.ts
+++ b/client/components/DragAndDropComponents/DraggableLongText/types.ts
@@ -1,11 +1,12 @@
 import { Control } from "react-hook-form";
-import { Field, Validation } from "../DNDCanvas/types";
+import { Field, Properties, Validation } from "../DNDCanvas/types";
 
 export interface DraggableLongTextProps {
   id: string;
   index: number;
   title: string;
   validations: Validation | undefined;
+  properties: Properties | undefined;
   control: Control<{ fields: Field[] }>;
   onDelete: () => void;
   onCopy: () => void;

--- a/client/components/DragAndDropComponents/DraggableMultipleChoice/DraggableMultipleChoice.module.css
+++ b/client/components/DragAndDropComponents/DraggableMultipleChoice/DraggableMultipleChoice.module.css
@@ -23,7 +23,7 @@
   margin-bottom: 8px;
 }
 
-.requiredSwitch {
+.switches {
   display: flex;
   gap: 10px;
   position: absolute;

--- a/client/components/DragAndDropComponents/DraggableMultipleChoice/DraggableMultipleChoice.tsx
+++ b/client/components/DragAndDropComponents/DraggableMultipleChoice/DraggableMultipleChoice.tsx
@@ -15,6 +15,7 @@ const DraggableMultipleChoice: React.FC<DraggableMultipleChoiceProps> = ({
   index,
   title,
   validations,
+  properties,
   control,
   onDelete,
   onCopy,
@@ -58,31 +59,58 @@ const DraggableMultipleChoice: React.FC<DraggableMultipleChoiceProps> = ({
                 border: "1px solid #DFE5EE",
                 borderRadius: 10,
               }}>
-              {validations?.required != null && (
-                <div className={styles.requiredSwitch}>
-                  <p className={styles.requiredText}>{t("requiredText")}</p>
-                  <Controller
-                    name={`fields.${index}.validations.required`}
-                    control={control}
-                    defaultValue={validations.required}
-                    render={({ field }) => (
-                      <Switch
-                        checked={field.value}
-                        onChange={(checked) => field.onChange(checked)}
-                        offColor="#DFE5EE"
-                        onColor="#DFE5EE"
-                        offHandleColor="#AAAAAA"
-                        onHandleColor="#B01254"
-                        handleDiameter={24}
-                        uncheckedIcon={false}
-                        checkedIcon={false}
-                        height={16}
-                        width={44}
-                      />
-                    )}
-                  />
-                </div>
-              )}
+              <div className={styles.switches}>
+                {validations?.required != null && (
+                  <>
+                    <p className={styles.requiredText}>{t("requiredText")}</p>
+                    <Controller
+                      name={`fields.${index}.validations.required`}
+                      control={control}
+                      defaultValue={validations.required}
+                      render={({ field }) => (
+                        <Switch
+                          checked={field.value}
+                          onChange={(checked) => field.onChange(checked)}
+                          offColor="#DFE5EE"
+                          onColor="#DFE5EE"
+                          offHandleColor="#AAAAAA"
+                          onHandleColor="#B01254"
+                          handleDiameter={24}
+                          uncheckedIcon={false}
+                          checkedIcon={false}
+                          height={16}
+                          width={44}
+                        />
+                      )}
+                    />
+                  </>
+                )}
+                {properties?.allow_multiple_selection != null && (
+                  <>
+                    <p className={styles.requiredText}>Multiple Selection</p>
+                    <Controller
+                      name={`fields.${index}.properties.allow_multiple_selection`}
+                      control={control}
+                      defaultValue={properties.allow_multiple_selection}
+                      render={({ field }) => (
+                        <Switch
+                          checked={field.value == null ? false : field.value}
+                          onChange={(checked) => field.onChange(checked)}
+                          offColor="#DFE5EE"
+                          onColor="#DFE5EE"
+                          offHandleColor="#AAAAAA"
+                          onHandleColor="#B01254"
+                          handleDiameter={24}
+                          uncheckedIcon={false}
+                          checkedIcon={false}
+                          height={16}
+                          width={44}
+                        />
+                      )}
+                    />
+                  </>
+                )}
+              </div>
               <Controller
                 name={`fields.${index}.title`}
                 control={control}

--- a/client/components/DragAndDropComponents/DraggableMultipleChoice/DraggableMultipleChoice.tsx
+++ b/client/components/DragAndDropComponents/DraggableMultipleChoice/DraggableMultipleChoice.tsx
@@ -87,7 +87,9 @@ const DraggableMultipleChoice: React.FC<DraggableMultipleChoiceProps> = ({
                 )}
                 {properties?.allow_multiple_selection != null && (
                   <>
-                    <p className={styles.requiredText}>Multiple Selection</p>
+                    <p className={styles.requiredText}>
+                      {t("multipleSelection")}
+                    </p>
                     <Controller
                       name={`fields.${index}.properties.allow_multiple_selection`}
                       control={control}

--- a/client/components/DragAndDropComponents/DraggableMultipleChoice/types.ts
+++ b/client/components/DragAndDropComponents/DraggableMultipleChoice/types.ts
@@ -1,11 +1,12 @@
 import { Control } from "react-hook-form";
-import { Field, Validation } from "../DNDCanvas/types";
+import { Field, Properties, Validation } from "../DNDCanvas/types";
 
 export interface DraggableMultipleChoiceProps {
   id: string;
   index: number;
   title: string;
   validations: Validation | undefined;
+  properties: Properties | undefined;
   control: Control<{ fields: Field[] }>; // Type as appropriate
   onDelete: () => void;
   onCopy: () => void;

--- a/client/i18n/en/components/DraggableFields.json
+++ b/client/i18n/en/components/DraggableFields.json
@@ -6,5 +6,6 @@
   "phoneNumber": "Phone Number",
   "shortText": "Short Text",
   "questionPlaceholder": "Question",
-  "requiredText": "Required"
+  "requiredText": "Required",
+  "multipleSelection": "Multiple Selection"
 }

--- a/client/i18n/esp/components/DraggableFields.json
+++ b/client/i18n/esp/components/DraggableFields.json
@@ -6,5 +6,6 @@
   "phoneNumber": "Número de Teléfono",
   "shortText": "Texto Corto",
   "questionPlaceholder": "Pregunta",
-  "requiredText": "Requerido"
+  "requiredText": "Requerido",
+  "multipleSelection": "Selección Múltiple"
 }


### PR DESCRIPTION
### Description
Added ability to multi select choices for multiple choice if checked through the form builder

#### Select multiple choice and toggle multi selection
![8ce23fbd86ea59fd1fe0bb967b292fe7](https://github.com/cascaritaco/cascarita/assets/33636358/c3d5ada5-49aa-4b1e-810e-836679082c69)

#### Typeforms multi select

![1cc5e8da3592a9874f993b1054ed8a0c](https://github.com/cascaritaco/cascarita/assets/33636358/41bb08d0-a431-46fc-89bf-d9bb8d15e8db)


#### Our custom form multi select

![c4005d1f58d8f8943c92c3f058e9f048](https://github.com/cascaritaco/cascarita/assets/33636358/26ad0a39-875a-48a4-924c-3c921f0bb30e)


### Checklist

- [x] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [x] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
