### PR TITLE
Feat (form builder): Payment Component

### DIFF
--- a/client/api/forms/types.ts
+++ b/client/api/forms/types.ts
@@ -19,7 +19,14 @@ export interface Label {
 
 export interface Properties {
   choices?: Label[];
+  allow_multiple_selection?: boolean;
   default_country_code?: string;
+  description?: string;
+  price?: {
+    type: string;
+    value: string;
+    currency: string;
+  };
 }
 
 export interface Field {

--- a/client/api/forms/types.ts
+++ b/client/api/forms/types.ts
@@ -4,7 +4,8 @@ export type FieldType =
   | "long_text"
   | "dropdown"
   | "email"
-  | "phone_number";
+  | "phone_number"
+  | "payment";
 
 export interface Validation {
   max_length?: number;

--- a/client/components/DragAndDropComponents/DNDCanvas/DNDCanvas.tsx
+++ b/client/components/DragAndDropComponents/DNDCanvas/DNDCanvas.tsx
@@ -16,6 +16,7 @@ import { v4 as uuidv4 } from "uuid";
 import DraggablePhoneNumber from "../DraggablePhoneNumber/DraggablePhoneNumber";
 import DraggableEmail from "../DraggableEmail/DraggableEmail";
 import { StrictModeDroppable } from "../../StrictModeDroppable/StrictModeDroppable";
+import DraggablePayment from "../DraggablePayment/DraggablePayment";
 
 const DNDCanvas = forwardRef(
   (
@@ -45,6 +46,7 @@ const DNDCanvas = forwardRef(
       long_text: DraggableLongText,
       email: DraggableEmail,
       phone_number: DraggablePhoneNumber,
+      payment: DraggablePayment,
     };
 
     const appendField = (item: DroppedItem) => {
@@ -91,6 +93,14 @@ const DNDCanvas = forwardRef(
           id: item.id,
           ref: item.id,
           properties: { default_country_code: "US" },
+          validations: { required: false },
+          type: item.type,
+        },
+        payment: {
+          title: "",
+          id: item.id,
+          ref: item.id,
+          properties: { currency: "USD" },
           validations: { required: false },
           type: item.type,
         },

--- a/client/components/DragAndDropComponents/DNDCanvas/DNDCanvas.tsx
+++ b/client/components/DragAndDropComponents/DNDCanvas/DNDCanvas.tsx
@@ -100,7 +100,10 @@ const DNDCanvas = forwardRef(
           title: "",
           id: item.id,
           ref: item.id,
-          properties: { currency: "USD" },
+          properties: {
+            price: { type: "fixed", value: "", currency: "USD" },
+            description: "",
+          },
           validations: { required: false },
           type: item.type,
         },

--- a/client/components/DragAndDropComponents/DNDCanvas/types.ts
+++ b/client/components/DragAndDropComponents/DNDCanvas/types.ts
@@ -23,7 +23,12 @@ export interface Properties {
   choices?: Label[];
   allow_multiple_selection?: boolean;
   default_country_code?: string;
-  currency?: string;
+  description?: string;
+  price?: {
+    type: string;
+    value: string;
+    currency: string;
+  };
 }
 
 export interface Field {

--- a/client/components/DragAndDropComponents/DNDCanvas/types.ts
+++ b/client/components/DragAndDropComponents/DNDCanvas/types.ts
@@ -6,7 +6,8 @@ export type FieldType =
   | "long_text"
   | "dropdown"
   | "email"
-  | "phone_number";
+  | "phone_number"
+  | "payment";
 
 export interface Validation {
   max_length?: number;
@@ -22,6 +23,7 @@ export interface Properties {
   choices?: Label[];
   allow_multiple_selection?: boolean;
   default_country_code?: string;
+  currency?: string;
 }
 
 export interface Field {

--- a/client/components/DragAndDropComponents/DraggableButton/DraggableButton.module.css
+++ b/client/components/DragAndDropComponents/DraggableButton/DraggableButton.module.css
@@ -12,11 +12,18 @@
   display: flex;
   border-radius: 10px;
   padding: 10px;
-  background-color: #1d74c5ff;
   color: white;
   align-items: center;
   height: 51px;
   width: 185px;
+}
+
+.standardButton {
+  background-color: #1d74c5ff;
+}
+
+.paymentButton {
+  background-color: #7560f9;
 }
 
 .baseStyle {

--- a/client/components/DragAndDropComponents/DraggableButton/DraggableButton.tsx
+++ b/client/components/DragAndDropComponents/DraggableButton/DraggableButton.tsx
@@ -14,6 +14,7 @@ import { GrTextAlignFull } from "react-icons/gr";
 import { TiPhoneOutline } from "react-icons/ti";
 import { useTranslation } from "react-i18next";
 import { PlusCircledIcon } from "@radix-ui/react-icons";
+import { FaDollarSign } from "react-icons/fa6";
 
 const iconMapping: { [key: string]: IconType } = {
   shorttext: MdOutlineShortText,
@@ -23,6 +24,7 @@ const iconMapping: { [key: string]: IconType } = {
   multiplechoice: FaListUl,
   email: MdOutlineMailOutline,
   phonenumber: TiPhoneOutline,
+  payment: FaDollarSign,
 };
 
 const DraggableButton: React.FC<DraggableButtonProps> = ({ label, onDrop }) => {
@@ -61,7 +63,10 @@ const DraggableButton: React.FC<DraggableButtonProps> = ({ label, onDrop }) => {
         position={dragPosition}
         onStop={handleDragStop}
         onDrag={(e, data) => setDragPosition({ x: data.x, y: data.y })}>
-        <button className={`${styles.buttonContainer} ${additionalClass}`}>
+        <button
+          className={`${styles.buttonContainer} ${additionalClass} ${
+            label === "Payment" ? styles.paymentButton : styles.standardButton
+          }`}>
           {IconComponent && <IconComponent />}
           <span className={styles.buttonText}>
             {t(`draggableButtons.${label}` as DraggableButtonKeys)}

--- a/client/components/DragAndDropComponents/DraggableDropdown/DraggableDropdown.module.css
+++ b/client/components/DragAndDropComponents/DraggableDropdown/DraggableDropdown.module.css
@@ -35,3 +35,11 @@
 .requiredText {
   line-height: 2;
 }
+
+.draggableContainer {
+  padding: 16px;
+  margin: 0 0 8px 0;
+  background-color: #ffffff;
+  border: 1px solid #dfe5ee;
+  border-radius: 10px;
+}

--- a/client/components/DragAndDropComponents/DraggableDropdown/DraggableDropdown.tsx
+++ b/client/components/DragAndDropComponents/DraggableDropdown/DraggableDropdown.tsx
@@ -23,7 +23,7 @@ const DraggableDropdown: React.FC<DraggableDropdownProps> = ({
   const { t } = useTranslation("DraggableFields");
 
   const handleClick = () => {
-    setIsMenuOpen((prev) => !prev);
+    setIsMenuOpen(!isMenuOpen);
   };
 
   const { fields, append, remove } = useFieldArray({
@@ -65,14 +65,7 @@ const DraggableDropdown: React.FC<DraggableDropdownProps> = ({
           onClick={handleClick}>
           <div style={{ position: "relative" }}>
             <p className={styles.textElementTypeText}>{t("dropDown")}</p>
-            <div
-              style={{
-                padding: 16,
-                margin: "0 0 8px 0",
-                background: "#FFFFFF",
-                border: "1px solid #DFE5EE",
-                borderRadius: 10,
-              }}>
+            <div className={styles.draggableContainer}>
               {validations?.required != null && (
                 <div className={styles.requiredSwitch}>
                   <p className={styles.requiredText}>{t("requiredText")}</p>

--- a/client/components/DragAndDropComponents/DraggableEmail/DraggableEmail.module.css
+++ b/client/components/DragAndDropComponents/DraggableEmail/DraggableEmail.module.css
@@ -36,3 +36,11 @@
 .requiredText {
   line-height: 2;
 }
+
+.draggableContainer {
+  padding: 16px;
+  margin: 0 0 8px 0;
+  background-color: #ffffff;
+  border: 1px solid #dfe5ee;
+  border-radius: 10px;
+}

--- a/client/components/DragAndDropComponents/DraggableEmail/DraggableEmail.tsx
+++ b/client/components/DragAndDropComponents/DraggableEmail/DraggableEmail.tsx
@@ -20,7 +20,7 @@ const DraggableEmail: React.FC<DraggableEmailProps> = ({
   const { t } = useTranslation("DraggableFields");
 
   const handleClick = () => {
-    setIsMenuOpen((prev) => !prev);
+    setIsMenuOpen(!isMenuOpen);
   };
 
   return (
@@ -34,14 +34,7 @@ const DraggableEmail: React.FC<DraggableEmailProps> = ({
           onClick={handleClick}>
           <div style={{ position: "relative" }}>
             <p className={styles.textElementTypeText}>{t("email")}</p>
-            <div
-              style={{
-                padding: 16,
-                margin: "0 0 8px 0",
-                background: "#FFFFFF",
-                border: "1px solid #DFE5EE",
-                borderRadius: 10,
-              }}>
+            <div className={styles.draggableContainer}>
               {validations?.required != null && (
                 <div className={styles.requiredSwitch}>
                   <p className={styles.requiredText}>{t("requiredText")}</p>

--- a/client/components/DragAndDropComponents/DraggableLongText/DraggableLongText.module.css
+++ b/client/components/DragAndDropComponents/DraggableLongText/DraggableLongText.module.css
@@ -42,3 +42,11 @@
   position: static;
   padding: 0;
 }
+
+.draggableContainer {
+  padding: 16px;
+  margin: 0 0 8px 0;
+  background-color: #ffffff;
+  border: 1px solid #dfe5ee;
+  border-radius: 10px;
+}

--- a/client/components/DragAndDropComponents/DraggableLongText/DraggableLongText.tsx
+++ b/client/components/DragAndDropComponents/DraggableLongText/DraggableLongText.tsx
@@ -40,7 +40,7 @@ const DraggableLongText: React.FC<DraggableLongTextProps> = ({
   }, []);
 
   const handleClick = () => {
-    setIsMenuOpen((prev) => !prev);
+    setIsMenuOpen(!isMenuOpen);
   };
 
   return (
@@ -54,14 +54,7 @@ const DraggableLongText: React.FC<DraggableLongTextProps> = ({
           onClick={handleClick}>
           <div style={{ position: "relative" }} ref={containerRef}>
             <p className={styles.textElementTypeText}>{t("longText")}</p>
-            <div
-              style={{
-                padding: 16,
-                margin: "0 0 8px 0",
-                background: "#FFFFFF",
-                border: "1px solid #DFE5EE",
-                borderRadius: 10,
-              }}>
+            <div className={styles.draggableContainer}>
               <Controller
                 key={index}
                 name={`fields.${index}.title`}

--- a/client/components/DragAndDropComponents/DraggableMultipleChoice/DraggableMultipleChoice.module.css
+++ b/client/components/DragAndDropComponents/DraggableMultipleChoice/DraggableMultipleChoice.module.css
@@ -35,3 +35,11 @@
 .requiredText {
   line-height: 2;
 }
+
+.draggableContainer {
+  padding: 16px;
+  margin: 0 0 8px 0;
+  background-color: #ffffff;
+  border: 1px solid #dfe5ee;
+  border-radius: 10px;
+}

--- a/client/components/DragAndDropComponents/DraggableMultipleChoice/DraggableMultipleChoice.tsx
+++ b/client/components/DragAndDropComponents/DraggableMultipleChoice/DraggableMultipleChoice.tsx
@@ -24,7 +24,7 @@ const DraggableMultipleChoice: React.FC<DraggableMultipleChoiceProps> = ({
   const { t } = useTranslation("DraggableFields");
 
   const handleClick = () => {
-    setIsMenuOpen((prev) => !prev);
+    setIsMenuOpen(!isMenuOpen);
   };
 
   const { fields, append, remove } = useFieldArray({
@@ -51,14 +51,7 @@ const DraggableMultipleChoice: React.FC<DraggableMultipleChoiceProps> = ({
           onClick={handleClick}>
           <div style={{ position: "relative" }}>
             <p className={styles.textElementTypeText}>{t("multipleChoice")}</p>
-            <div
-              style={{
-                padding: 16,
-                margin: "0 0 8px 0",
-                background: "#FFFFFF",
-                border: "1px solid #DFE5EE",
-                borderRadius: 10,
-              }}>
+            <div className={styles.draggableContainer}>
               <div className={styles.switches}>
                 {validations?.required != null && (
                   <>

--- a/client/components/DragAndDropComponents/DraggablePayment/DraggablePayment.module.css
+++ b/client/components/DragAndDropComponents/DraggablePayment/DraggablePayment.module.css
@@ -1,0 +1,44 @@
+.requiredText,
+.textElementTypeText {
+  font-family: "DM Sans";
+  font-weight: 400;
+  font-size: 12px;
+}
+
+.textElementTypeText {
+  font-style: normal;
+  line-height: 24px;
+  color: #aaaaaa;
+}
+
+.question {
+  margin-left: -5px;
+  margin-right: -5px;
+  padding-left: 5px;
+  padding-right: 5px;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 25px;
+  width: 65%;
+  margin-bottom: 8px;
+}
+
+.extraOptions {
+  display: flex;
+  gap: 10px;
+  position: absolute;
+  top: 25px;
+  padding: 10px;
+  right: 0;
+}
+
+.requiredText {
+  line-height: 2;
+}
+
+.containerSmall.extraOptions {
+  flex-direction: column;
+  position: static;
+  padding: 0;
+}

--- a/client/components/DragAndDropComponents/DraggablePayment/DraggablePayment.module.css
+++ b/client/components/DragAndDropComponents/DraggablePayment/DraggablePayment.module.css
@@ -42,3 +42,61 @@
   position: static;
   padding: 0;
 }
+
+.payment {
+  display: flex;
+  font-style: normal;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 25px;
+}
+
+.paymentText {
+  margin-top: 10px;
+  height: 40px;
+  padding: 10px 10px 10px 0;
+  color: #000000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.paymentInputGroup {
+  margin-top: 10px;
+  display: flex;
+  width: 130px;
+  height: 40px;
+  align-items: center;
+  padding: 10px;
+  border: 1px solid #dfe5ee;
+  border-radius: 10px;
+  background-color: #f4f4f4;
+}
+
+.currencySymbol {
+  padding: 0 10px;
+  font-size: 16px;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 21px;
+  color: #8d8d8d;
+}
+
+.paymentInput {
+  flex: 1;
+  border: none !important;
+  outline: none !important;
+  padding: 0;
+  color: #000000;
+  background-color: transparent;
+}
+
+.currency {
+  margin-top: 10px;
+  height: 40px;
+  padding: 10px;
+  color: #000000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/client/components/DragAndDropComponents/DraggablePayment/DraggablePayment.module.css
+++ b/client/components/DragAndDropComponents/DraggablePayment/DraggablePayment.module.css
@@ -100,3 +100,11 @@
   justify-content: center;
   align-items: center;
 }
+
+.draggableContainer {
+  padding: 16px;
+  margin: 0 0 8px 0;
+  background-color: #ffffff;
+  border: 1px solid #dfe5ee;
+  border-radius: 10px;
+}

--- a/client/components/DragAndDropComponents/DraggablePayment/DraggablePayment.tsx
+++ b/client/components/DragAndDropComponents/DraggablePayment/DraggablePayment.tsx
@@ -72,7 +72,7 @@ const DraggablePayment: React.FC<DraggablePaymentProps> = ({
                 render={({ field }) => (
                   <input
                     {...field}
-                    placeholder={"Title"}
+                    placeholder={t("title")}
                     className={styles.question}
                   />
                 )}
@@ -85,7 +85,7 @@ const DraggablePayment: React.FC<DraggablePaymentProps> = ({
                   render={({ field }) => (
                     <input
                       {...field}
-                      placeholder={"Description"}
+                      placeholder={t("description")}
                       className={styles.question}
                     />
                   )}
@@ -95,7 +95,7 @@ const DraggablePayment: React.FC<DraggablePaymentProps> = ({
               {properties?.price != null && (
                 <>
                   <div className={styles.payment}>
-                    <p className={styles.paymentText}>Payment Amount: </p>
+                    <p className={styles.paymentText}>{t("paymentAmount")}: </p>
                     <div className={styles.paymentInputGroup}>
                       <p className={styles.currencySymbol}>$</p>
                       <Controller

--- a/client/components/DragAndDropComponents/DraggablePayment/DraggablePayment.tsx
+++ b/client/components/DragAndDropComponents/DraggablePayment/DraggablePayment.tsx
@@ -7,6 +7,7 @@ import DraggableSubMenu from "../DraggableSubMenu/DraggableSubMenu";
 import Switch from "react-switch";
 import { useTranslation } from "react-i18next";
 import { SMALL_DRAGGABLE_CONTAINER_WIDTH } from "../constants";
+import { formatPayment } from "../../../util/formatPayment";
 
 const DraggablePayment: React.FC<DraggablePaymentProps> = ({
   id,
@@ -14,6 +15,7 @@ const DraggablePayment: React.FC<DraggablePaymentProps> = ({
   title,
   control,
   validations,
+  properties,
   onDelete,
   onCopy,
 }) => {
@@ -68,43 +70,66 @@ const DraggablePayment: React.FC<DraggablePaymentProps> = ({
                 control={control}
                 defaultValue={title} // Ensure the default value is set
                 render={({ field }) => (
-                  <>
-                    <input
-                      {...field}
-                      placeholder={t("questionPlaceholder")}
-                      className={styles.question}
-                    />
-                    <hr />
-                  </>
+                  <input
+                    {...field}
+                    placeholder={"Title"}
+                    className={styles.question}
+                  />
                 )}
               />
+              {properties?.description != null && (
+                <Controller
+                  name={`fields.${index}.properties.description`}
+                  control={control}
+                  defaultValue={properties?.description}
+                  render={({ field }) => (
+                    <input
+                      {...field}
+                      placeholder={"Description"}
+                      className={styles.question}
+                    />
+                  )}
+                />
+              )}
+              <hr />
+              {properties?.price != null && (
+                <>
+                  <div className={styles.payment}>
+                    <p className={styles.paymentText}>Payment Amount: </p>
+                    <div className={styles.paymentInputGroup}>
+                      <p className={styles.currencySymbol}>$</p>
+                      <Controller
+                        key={index}
+                        name={`fields.${index}.properties.price.value`}
+                        control={control}
+                        defaultValue={properties.price.value}
+                        render={({ field }) => (
+                          <input
+                            {...field}
+                            value={formatPayment(field.value)}
+                            placeholder={"0.00"}
+                            className={styles.paymentInput}
+                          />
+                        )}
+                      />
+                    </div>
+                    <p className={styles.currency}>
+                      {properties.price?.currency}
+                    </p>
+                  </div>
+                </>
+              )}
+              {/* TODO: Add Stripe Accounts */}
+              <select className={styles.input}>
+                <option value="">Select an Account</option>
+                <option value="1">Account 1</option>
+                <option value="2">Account 2</option>
+                <option value="3">Account 3</option>
+              </select>
               <div
                 className={`${styles.extraOptions} ${
                   isContainerWidthMaxed ? styles.containerSmall : ""
                 }`}>
-                {validations?.max_length != null && (
-                  <>
-                    <p className={styles.requiredText}>{t("maxCharacters")}</p>
-                    <Controller
-                      name={`fields.${index}.validations.max_length`}
-                      control={control}
-                      defaultValue={validations.max_length}
-                      render={({ field }) => (
-                        <>
-                          <input
-                            {...field}
-                            type="number"
-                            min={0}
-                            max={10000}
-                            placeholder={"0 - 10,000"}
-                            className={styles.requiredText}
-                          />
-                          <hr />
-                        </>
-                      )}
-                    />
-                  </>
-                )}
                 {validations?.required != null && (
                   <>
                     <p className={styles.requiredText}>{t("requiredText")}</p>

--- a/client/components/DragAndDropComponents/DraggablePayment/DraggablePayment.tsx
+++ b/client/components/DragAndDropComponents/DraggablePayment/DraggablePayment.tsx
@@ -1,14 +1,14 @@
 import React, { useEffect, useRef, useState } from "react";
 import { Controller } from "react-hook-form";
 import { Draggable } from "react-beautiful-dnd";
-import { DraggableShortTextProps } from "./types";
-import styles from "./DraggableShortText.module.css";
+import { DraggablePaymentProps } from "./types";
+import styles from "./DraggablePayment.module.css";
 import DraggableSubMenu from "../DraggableSubMenu/DraggableSubMenu";
 import Switch from "react-switch";
 import { useTranslation } from "react-i18next";
 import { SMALL_DRAGGABLE_CONTAINER_WIDTH } from "../constants";
 
-const DraggableShortText: React.FC<DraggableShortTextProps> = ({
+const DraggablePayment: React.FC<DraggablePaymentProps> = ({
   id,
   index,
   title,
@@ -53,7 +53,7 @@ const DraggableShortText: React.FC<DraggableShortTextProps> = ({
           style={provided.draggableProps.style}
           onClick={handleClick}>
           <div style={{ position: "relative" }} ref={containerRef}>
-            <p className={styles.textElementTypeText}>{t("shortText")}</p>
+            <p className={styles.textElementTypeText}>{t("payment")}</p>
             <div
               style={{
                 padding: 16,
@@ -146,4 +146,4 @@ const DraggableShortText: React.FC<DraggableShortTextProps> = ({
   );
 };
 
-export default DraggableShortText;
+export default DraggablePayment;

--- a/client/components/DragAndDropComponents/DraggablePayment/DraggablePayment.tsx
+++ b/client/components/DragAndDropComponents/DraggablePayment/DraggablePayment.tsx
@@ -42,7 +42,16 @@ const DraggablePayment: React.FC<DraggablePaymentProps> = ({
   }, []);
 
   const handleClick = () => {
-    setIsMenuOpen((prev) => !prev);
+    setIsMenuOpen(!isMenuOpen);
+  };
+
+  const getAccounts = () => {
+    const accounts = [];
+    accounts.push(<option value="">Select an Account</option>);
+    for (let i = 1; i < 5; ++i) {
+      accounts.push(<option value={i}>Account {i}</option>);
+    }
+    return accounts;
   };
 
   return (
@@ -56,14 +65,7 @@ const DraggablePayment: React.FC<DraggablePaymentProps> = ({
           onClick={handleClick}>
           <div style={{ position: "relative" }} ref={containerRef}>
             <p className={styles.textElementTypeText}>{t("payment")}</p>
-            <div
-              style={{
-                padding: 16,
-                margin: "0 0 8px 0",
-                background: "#FFFFFF",
-                border: "1px solid #DFE5EE",
-                borderRadius: 10,
-              }}>
+            <div className={styles.draggableContainer}>
               <Controller
                 key={index}
                 name={`fields.${index}.title`}
@@ -120,12 +122,7 @@ const DraggablePayment: React.FC<DraggablePaymentProps> = ({
                 </>
               )}
               {/* TODO: Add Stripe Accounts */}
-              <select className={styles.input}>
-                <option value="">Select an Account</option>
-                <option value="1">Account 1</option>
-                <option value="2">Account 2</option>
-                <option value="3">Account 3</option>
-              </select>
+              <select className={styles.input}>{getAccounts()}</select>
               <div
                 className={`${styles.extraOptions} ${
                   isContainerWidthMaxed ? styles.containerSmall : ""

--- a/client/components/DragAndDropComponents/DraggablePayment/DraggablePayment.tsx
+++ b/client/components/DragAndDropComponents/DraggablePayment/DraggablePayment.tsx
@@ -1,0 +1,149 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Controller } from "react-hook-form";
+import { Draggable } from "react-beautiful-dnd";
+import { DraggableShortTextProps } from "./types";
+import styles from "./DraggableShortText.module.css";
+import DraggableSubMenu from "../DraggableSubMenu/DraggableSubMenu";
+import Switch from "react-switch";
+import { useTranslation } from "react-i18next";
+import { SMALL_DRAGGABLE_CONTAINER_WIDTH } from "../constants";
+
+const DraggableShortText: React.FC<DraggableShortTextProps> = ({
+  id,
+  index,
+  title,
+  control,
+  validations,
+  onDelete,
+  onCopy,
+}) => {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const { t } = useTranslation("DraggableFields");
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isContainerWidthMaxed, setIsContainerWidthMaxed] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (containerRef.current) {
+        setIsContainerWidthMaxed(
+          containerRef.current.offsetWidth < SMALL_DRAGGABLE_CONTAINER_WIDTH,
+        );
+      }
+    };
+
+    handleResize();
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  const handleClick = () => {
+    setIsMenuOpen((prev) => !prev);
+  };
+
+  return (
+    <Draggable draggableId={id} index={index}>
+      {(provided) => (
+        <div
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+          style={provided.draggableProps.style}
+          onClick={handleClick}>
+          <div style={{ position: "relative" }} ref={containerRef}>
+            <p className={styles.textElementTypeText}>{t("shortText")}</p>
+            <div
+              style={{
+                padding: 16,
+                margin: "0 0 8px 0",
+                background: "#FFFFFF",
+                border: "1px solid #DFE5EE",
+                borderRadius: 10,
+              }}>
+              <Controller
+                key={index}
+                name={`fields.${index}.title`}
+                control={control}
+                defaultValue={title} // Ensure the default value is set
+                render={({ field }) => (
+                  <>
+                    <input
+                      {...field}
+                      placeholder={t("questionPlaceholder")}
+                      className={styles.question}
+                    />
+                    <hr />
+                  </>
+                )}
+              />
+              <div
+                className={`${styles.extraOptions} ${
+                  isContainerWidthMaxed ? styles.containerSmall : ""
+                }`}>
+                {validations?.max_length != null && (
+                  <>
+                    <p className={styles.requiredText}>{t("maxCharacters")}</p>
+                    <Controller
+                      name={`fields.${index}.validations.max_length`}
+                      control={control}
+                      defaultValue={validations.max_length}
+                      render={({ field }) => (
+                        <>
+                          <input
+                            {...field}
+                            type="number"
+                            min={0}
+                            max={10000}
+                            placeholder={"0 - 10,000"}
+                            className={styles.requiredText}
+                          />
+                          <hr />
+                        </>
+                      )}
+                    />
+                  </>
+                )}
+                {validations?.required != null && (
+                  <>
+                    <p className={styles.requiredText}>{t("requiredText")}</p>
+                    <Controller
+                      name={`fields.${index}.validations.required`}
+                      control={control}
+                      defaultValue={validations.required}
+                      render={({ field }) => (
+                        <Switch
+                          checked={field.value}
+                          onChange={(checked) => field.onChange(checked)}
+                          offColor="#DFE5EE"
+                          onColor="#DFE5EE"
+                          offHandleColor="#AAAAAA"
+                          onHandleColor="#B01254"
+                          handleDiameter={24}
+                          uncheckedIcon={false}
+                          checkedIcon={false}
+                          height={16}
+                          width={44}
+                        />
+                      )}
+                    />
+                  </>
+                )}
+              </div>
+            </div>
+            {isMenuOpen && (
+              <DraggableSubMenu
+                onDelete={onDelete}
+                onCopy={onCopy}
+                onClose={handleClick}
+              />
+            )}
+          </div>
+        </div>
+      )}
+    </Draggable>
+  );
+};
+
+export default DraggableShortText;

--- a/client/components/DragAndDropComponents/DraggablePayment/types.ts
+++ b/client/components/DragAndDropComponents/DraggablePayment/types.ts
@@ -1,0 +1,12 @@
+import { Control } from "react-hook-form";
+import { Field, Validation } from "../DNDCanvas/types";
+
+export interface DraggableShortTextProps {
+  id: string;
+  index: number;
+  title: string;
+  validations: Validation | undefined;
+  control: Control<{ fields: Field[] }>;
+  onDelete: () => void;
+  onCopy: () => void;
+}

--- a/client/components/DragAndDropComponents/DraggablePayment/types.ts
+++ b/client/components/DragAndDropComponents/DraggablePayment/types.ts
@@ -1,7 +1,7 @@
 import { Control } from "react-hook-form";
 import { Field, Validation } from "../DNDCanvas/types";
 
-export interface DraggableShortTextProps {
+export interface DraggablePaymentProps {
   id: string;
   index: number;
   title: string;

--- a/client/components/DragAndDropComponents/DraggablePayment/types.ts
+++ b/client/components/DragAndDropComponents/DraggablePayment/types.ts
@@ -1,11 +1,12 @@
 import { Control } from "react-hook-form";
-import { Field, Validation } from "../DNDCanvas/types";
+import { Field, Properties, Validation } from "../DNDCanvas/types";
 
 export interface DraggablePaymentProps {
   id: string;
   index: number;
   title: string;
   validations: Validation | undefined;
+  properties: Properties | undefined;
   control: Control<{ fields: Field[] }>;
   onDelete: () => void;
   onCopy: () => void;

--- a/client/components/DragAndDropComponents/DraggablePhoneNumber/DraggablePhoneNumber.module.css
+++ b/client/components/DragAndDropComponents/DraggablePhoneNumber/DraggablePhoneNumber.module.css
@@ -36,3 +36,11 @@
 .requiredText {
   line-height: 2;
 }
+
+.draggableContainer {
+  padding: 16px;
+  margin: 0 0 8px 0;
+  background-color: #ffffff;
+  border: 1px solid #dfe5ee;
+  border-radius: 10px;
+}

--- a/client/components/DragAndDropComponents/DraggablePhoneNumber/DraggablePhoneNumber.tsx
+++ b/client/components/DragAndDropComponents/DraggablePhoneNumber/DraggablePhoneNumber.tsx
@@ -20,7 +20,7 @@ const DraggablePhoneNumber: React.FC<DraggablePhoneNumberProps> = ({
   const { t } = useTranslation("DraggableFields");
 
   const handleClick = () => {
-    setIsMenuOpen((prev) => !prev);
+    setIsMenuOpen(!isMenuOpen);
   };
 
   return (
@@ -34,14 +34,7 @@ const DraggablePhoneNumber: React.FC<DraggablePhoneNumberProps> = ({
           onClick={handleClick}>
           <div style={{ position: "relative" }}>
             <p className={styles.textElementTypeText}>{t("phoneNumber")}</p>
-            <div
-              style={{
-                padding: 16,
-                margin: "0 0 8px 0",
-                background: "#FFFFFF",
-                border: "1px solid #DFE5EE",
-                borderRadius: 10,
-              }}>
+            <div className={styles.draggableContainer}>
               {validations?.required != null && (
                 <div className={styles.requiredSwitch}>
                   <p className={styles.requiredText}>{t("requiredText")}</p>

--- a/client/components/DragAndDropComponents/DraggableShortText/DraggableShortText.module.css
+++ b/client/components/DragAndDropComponents/DraggableShortText/DraggableShortText.module.css
@@ -42,3 +42,11 @@
   position: static;
   padding: 0;
 }
+
+.draggableContainer {
+  padding: 16px;
+  margin: 0 0 8px 0;
+  background-color: #ffffff;
+  border: 1px solid #dfe5ee;
+  border-radius: 10px;
+}

--- a/client/components/DragAndDropComponents/DraggableShortText/DraggableShortText.tsx
+++ b/client/components/DragAndDropComponents/DraggableShortText/DraggableShortText.tsx
@@ -40,7 +40,7 @@ const DraggableShortText: React.FC<DraggableShortTextProps> = ({
   }, []);
 
   const handleClick = () => {
-    setIsMenuOpen((prev) => !prev);
+    setIsMenuOpen(!isMenuOpen);
   };
 
   return (
@@ -54,14 +54,7 @@ const DraggableShortText: React.FC<DraggableShortTextProps> = ({
           onClick={handleClick}>
           <div style={{ position: "relative" }} ref={containerRef}>
             <p className={styles.textElementTypeText}>{t("shortText")}</p>
-            <div
-              style={{
-                padding: 16,
-                margin: "0 0 8px 0",
-                background: "#FFFFFF",
-                border: "1px solid #DFE5EE",
-                borderRadius: 10,
-              }}>
+            <div className={styles.draggableContainer}>
               <Controller
                 key={index}
                 name={`fields.${index}.title`}

--- a/client/components/FormInputComponents/Payment/Payment.module.css
+++ b/client/components/FormInputComponents/Payment/Payment.module.css
@@ -1,0 +1,59 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  padding: 20px 0;
+  gap: 10px;
+}
+
+.question {
+  font-size: 18px;
+  font-weight: 800;
+  line-height: 28px;
+}
+
+.input {
+  background-color: #f6f9fd;
+  padding: 9px;
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 24px;
+  border-radius: 15px;
+}
+
+.errorMessage {
+  color: red;
+  font-size: 14px;
+  padding-bottom: 9px;
+  font-weight: 400;
+}
+
+.required {
+  color: red;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.questionContainer {
+  display: flex;
+  gap: 5px;
+  flex-direction: row;
+}
+
+@media (max-width: 600px) {
+  .question {
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  .input {
+    padding: 7px;
+    font-size: 16px;
+    line-height: 22px;
+    border-radius: 10px;
+  }
+
+  .errorMessage {
+    font-size: 12px;
+    padding-bottom: 7px;
+  }
+}

--- a/client/components/FormInputComponents/Payment/Payment.tsx
+++ b/client/components/FormInputComponents/Payment/Payment.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { FieldProps } from "../types";
+import styles from "./ShortText.module.css";
+
+const Payment = ({ field, index }: FieldProps) => {
+  return (
+    <section className={styles.container}>
+      <div className={styles.questionContainer}>
+        <h3 className={styles.question}>
+          Question: {field.title} {index}
+        </h3>
+        {field.validations?.required && (
+          <span className={styles.required}>*</span>
+        )}
+      </div>
+      {/* TODO: Create the Stripe form through here*/}
+    </section>
+  );
+};
+
+export default Payment;

--- a/client/components/FormInputComponents/types.ts
+++ b/client/components/FormInputComponents/types.ts
@@ -21,6 +21,12 @@ export interface Properties {
   choices?: Label[];
   allow_multiple_selection?: boolean;
   default_country_code?: string;
+  description?: string;
+  price?: {
+    type: string;
+    value: string;
+    currency: string;
+  };
 }
 
 export interface Field {

--- a/client/i18n/en/components/DraggableButtons.json
+++ b/client/i18n/en/components/DraggableButtons.json
@@ -5,6 +5,7 @@
     "Dropdown": "Dropdown",
     "Multiple Choice": "Multiple Choice",
     "Email": "Email",
-    "Phone Number": "Phone Number"
+    "Phone Number": "Phone Number",
+    "Payment": "Payment"
   }
 }

--- a/client/i18n/en/components/DraggableFields.json
+++ b/client/i18n/en/components/DraggableFields.json
@@ -9,5 +9,8 @@
   "requiredText": "Required",
   "multipleSelection": "Multiple Selection",
   "maxCharacters": "Max Characters",
-  "payment": "Payment"
+  "payment": "Payment",
+  "title": "Title",
+  "description": "Description",
+  "paymentAmount": "Payment Amount"
 }

--- a/client/i18n/en/components/DraggableFields.json
+++ b/client/i18n/en/components/DraggableFields.json
@@ -8,5 +8,6 @@
   "questionPlaceholder": "Question",
   "requiredText": "Required",
   "multipleSelection": "Multiple Selection",
-  "maxCharacters": "Max Characters"
+  "maxCharacters": "Max Characters",
+  "payment": "Payment"
 }

--- a/client/i18n/esp/components/DraggableButtons.json
+++ b/client/i18n/esp/components/DraggableButtons.json
@@ -5,6 +5,7 @@
     "Dropdown": "Desplegable",
     "Multiple Choice": "Elección Múltiple",
     "Email": "Correo Electrónico",
-    "Phone Number": "Número de Teléfono"
+    "Phone Number": "Número de Teléfono",
+    "Payment": "Pago"
   }
 }

--- a/client/i18n/esp/components/DraggableFields.json
+++ b/client/i18n/esp/components/DraggableFields.json
@@ -9,5 +9,8 @@
   "requiredText": "Requerido",
   "multipleSelection": "Selección Múltiple",
   "maxCharacters": "Máximo de Caracteres",
-  "payment": "Pago"
+  "payment": "Pago",
+  "title": "Título",
+  "description": "Descripción",
+  "paymentAmount": "Cantidad de Pago"
 }

--- a/client/i18n/esp/components/DraggableFields.json
+++ b/client/i18n/esp/components/DraggableFields.json
@@ -8,5 +8,6 @@
   "questionPlaceholder": "Pregunta",
   "requiredText": "Requerido",
   "multipleSelection": "Selección Múltiple",
-  "maxCharacters": "Máximo de Caracteres"
+  "maxCharacters": "Máximo de Caracteres",
+  "payment": "Pago"
 }

--- a/client/pages/NewForm/NewForm.module.css
+++ b/client/pages/NewForm/NewForm.module.css
@@ -16,7 +16,7 @@ h4 {
   justify-content: left;
   background-color: #f4f7fb;
   border-radius: 10px;
-  z-index: 3;
+  overflow-y: auto;
 }
 
 .newFormContainer {

--- a/client/pages/NewForm/NewForm.module.css
+++ b/client/pages/NewForm/NewForm.module.css
@@ -16,7 +16,6 @@ h4 {
   justify-content: left;
   background-color: #f4f7fb;
   border-radius: 10px;
-  overflow-y: auto;
 }
 
 .newFormContainer {

--- a/client/pages/NewForm/NewForm.tsx
+++ b/client/pages/NewForm/NewForm.tsx
@@ -49,6 +49,7 @@ const NewForm = () => {
     "Multiple Choice",
     "Email",
     "Phone Number",
+    "Payment",
   ];
 
   const handleDrop = (label: DroppedItemType) => {

--- a/client/pages/NewForm/NewForm.tsx
+++ b/client/pages/NewForm/NewForm.tsx
@@ -96,7 +96,7 @@ const NewForm = () => {
 
   // TODO: save by mongo form ID
   const onSave = async (data: Form) => {
-    if (formId == null || formId === undefined) {
+    if (formId == null) {
       throw new Error("Form ID is undefined");
     }
     const response = await updateForm(

--- a/client/pages/NewForm/types.ts
+++ b/client/pages/NewForm/types.ts
@@ -4,7 +4,8 @@ export type DroppedItemType =
   | "dropdown"
   | "multiple_choice"
   | "email"
-  | "phone_number";
+  | "phone_number"
+  | "payment";
 
 export interface DroppedItem {
   id: string;

--- a/client/util/formatPayment.ts
+++ b/client/util/formatPayment.ts
@@ -1,0 +1,32 @@
+// Method to format payment based off of Stripe limitations
+
+export const formatPayment = (value: string) => {
+  let sanitizedValue = value.replace(/[^0-9.]/g, ""); // removes everything that is not a number
+  const decimalPosition = value.indexOf(".");
+  if (decimalPosition !== -1) {
+    // Ensures 1 decimal point
+    const firstDecimal = sanitizedValue.slice(0, decimalPosition + 1);
+    const rest = sanitizedValue.slice(decimalPosition + 1).replace(/\./g, "");
+    sanitizedValue = firstDecimal + rest;
+
+    // Ensures there are no more than two digits after the decimal point
+    const beforeDecimal = sanitizedValue.slice(0, decimalPosition);
+    const afterDecimal = sanitizedValue.slice(decimalPosition + 1).slice(0, 2);
+    sanitizedValue = beforeDecimal + "." + afterDecimal;
+  }
+
+  // Ensure maximum of 6 digits before the decimal point
+  if (sanitizedValue.indexOf(".") !== -1) {
+    const beforeDecimal = sanitizedValue.split(".")[0];
+    if (beforeDecimal.length > 6) {
+      sanitizedValue =
+        beforeDecimal.slice(0, 6) + "." + sanitizedValue.split(".")[1];
+    }
+  } else {
+    if (sanitizedValue.length > 6) {
+      sanitizedValue = sanitizedValue.slice(0, 6);
+    }
+  }
+
+  return sanitizedValue;
+};


### PR DESCRIPTION
## Changes
1. Added Draggable Payment component
2. Added a util function to normalize payment amount (to adjust for Stripe limitations)
3. Added Translations

## Purpose

In preparation for the stripe component when we build the form based off of [figma](https://www.figma.com/design/0RPE1KFkTvkcdvWoYsrxhe/cascarita-logo-ideas?node-id=1515-1275&t=DCVRwbvWljCxKhow-0) designs

![image](https://github.com/user-attachments/assets/d3df3f73-0004-4858-932a-d6081ffc2d03)


### Note
1. When the form is created, there won't be any component for this field (Will be done in another PR)
2. Builder Payment component still needs to be able to retrieve all accounts. (Currently blocked on this)
3. Will eventually need to create a drop down for the currency, but since we're sticking with USD for now, I jut left this as is

