### PR TITLE
fix: preserving nav state upon reloads

### DIFF
--- a/client/components/SideNav/SideNav.tsx
+++ b/client/components/SideNav/SideNav.tsx
@@ -8,34 +8,43 @@ import { IoSettingsOutline } from "react-icons/io5";
 import { TbLogout } from "react-icons/tb";
 import LogoutButton from "../LogoutButton/LogoutButton";
 import NavItem from "../NavItem/NavItem";
-import { useNavigate } from "react-router-dom";
+import { useState, useEffect } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
 const SideNav: React.FC<SideNavProps> = ({ selectedItem, setSelectedItem }) => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { t } = useTranslation("SideNav");
+  const [route, setRoute] = useState("/");
+
+  useEffect(() => {
+    const currentPath = location.pathname.substring(1); // Remove the leading '/'
+    setRoute(currentPath || "/");
+    setSelectedItem(currentPath);
+  }, [location.pathname, setSelectedItem]);
 
   const handleItemClick = (labelType: string) => {
-    let route: string;
-
+    let newRoute = "/";
     switch (labelType) {
       case "item1":
-        route = "";
+        newRoute = "";
         break;
       case "item2":
-        route = "users";
+        newRoute = "users";
         break;
       case "item4":
-        route = "forms";
+        newRoute = "forms";
         break;
       case "item5":
-        route = "settings";
+        newRoute = "settings";
         break;
       default:
-        route = "/";
+        newRoute = "/";
     }
-    setSelectedItem(route);
-    navigate(`/${route}`);
+    setRoute(newRoute);
+    setSelectedItem(newRoute);
+    navigate(`/${newRoute}`);
   };
 
   return (
@@ -84,4 +93,5 @@ const SideNav: React.FC<SideNavProps> = ({ selectedItem, setSelectedItem }) => {
     </nav>
   );
 };
+
 export default SideNav;

--- a/client/components/SideNav/SideNav.tsx
+++ b/client/components/SideNav/SideNav.tsx
@@ -16,11 +16,9 @@ const SideNav: React.FC<SideNavProps> = ({ selectedItem, setSelectedItem }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const { t } = useTranslation("SideNav");
-  const [route, setRoute] = useState("/");
 
   useEffect(() => {
     const currentPath = location.pathname.substring(1); // Remove the leading '/'
-    setRoute(currentPath || "/");
     setSelectedItem(currentPath);
   }, [location.pathname, setSelectedItem]);
 
@@ -42,7 +40,6 @@ const SideNav: React.FC<SideNavProps> = ({ selectedItem, setSelectedItem }) => {
       default:
         newRoute = "/";
     }
-    setRoute(newRoute);
     setSelectedItem(newRoute);
     navigate(`/${newRoute}`);
   };

--- a/client/components/SideNav/SideNav.tsx
+++ b/client/components/SideNav/SideNav.tsx
@@ -8,7 +8,7 @@ import { IoSettingsOutline } from "react-icons/io5";
 import { TbLogout } from "react-icons/tb";
 import LogoutButton from "../LogoutButton/LogoutButton";
 import NavItem from "../NavItem/NavItem";
-import { useState, useEffect } from "react";
+import { useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 

--- a/client/components/SideNav/SideNav.tsx
+++ b/client/components/SideNav/SideNav.tsx
@@ -51,7 +51,7 @@ const SideNav: React.FC<SideNavProps> = ({ selectedItem, setSelectedItem }) => {
           icon={<RiHomeLine />}
           label={t("item1")}
           labelType="item1"
-          selected={selectedItem === ""}
+          selected={selectedItem === "" || selectedItem.includes("season")}
           onItemClick={handleItemClick}
         />
         <NavItem
@@ -73,14 +73,14 @@ const SideNav: React.FC<SideNavProps> = ({ selectedItem, setSelectedItem }) => {
           icon={<HiOutlinePencilAlt />}
           label={t("item4")}
           labelType="item4"
-          selected={selectedItem === "forms"}
+          selected={selectedItem.includes("forms")}
           onItemClick={handleItemClick}
         />
         <NavItem
           icon={<IoSettingsOutline />}
           label={t("item5")}
           labelType="item5"
-          selected={selectedItem === "settings"}
+          selected={selectedItem.includes("settings")}
           onItemClick={handleItemClick}
         />
       </ul>


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes introduced by this pull request -->
Fix for #137. Nav Bar now preserves state when reloading. It will show you the correct corresponding page! See below for fix:

![Recording 2024-10-23 at 23 54 11](https://github.com/user-attachments/assets/b5801632-61f3-4206-baa7-a53bd5a7f287)


### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->

### Checklist

- [ ] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [X] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
