### PR TITLE
fix: add user by removing password as handled by Auth0

### DIFF
--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -272,20 +272,10 @@ const UserController = function () {
           .json({ error: "Email already exists within the group" });
       }
 
-      const randomPassword = crypto
-        .randomBytes(12)
-        .toString("base64")
-        .slice(0, 12);
-
-      // TODO: Send email to new user with password
-
-      const hashedPassword = await bcrypt.hash(randomPassword, 10);
-
       const newUser = {
         first_name,
         last_name,
         email,
-        password: hashedPassword,
         role_id,
         language_id: 1,
         group_id,


### PR DESCRIPTION
### Description

<!-- Provide a brief description of the changes introduced by this pull request -->
Noticed that `bycrypt` was being used for password generation. All passwords and role handling should go through Auth0 so we should be okay to remove that dependency as needed.

### Issue Link

<!-- Provide a link to the related issue on GitHub or another issue tracking system (ie Jira) -->
#147 

### Checklist

- [X] I have tested the changes locally by running `npm run test`
- [ ] I have added or updated relevant documentation
- [X] I have autoformatted the code by running `npm run eslint`
- [ ] I have added test cases (if applicable)

### Additional Notes
